### PR TITLE
Allow extension types to be inherited.

### DIFF
--- a/src/async.c
+++ b/src/async.c
@@ -154,7 +154,7 @@ static PyTypeObject AsyncType = {
     0,                                                              /*tp_getattro*/
     0,                                                              /*tp_setattro*/
     0,                                                              /*tp_as_buffer*/
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,                        /*tp_flags*/
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HAVE_GC,  /*tp_flags*/
     0,                                                              /*tp_doc*/
     (traverseproc)Async_tp_traverse,                                /*tp_traverse*/
     (inquiry)Async_tp_clear,                                        /*tp_clear*/

--- a/src/check.c
+++ b/src/check.c
@@ -180,7 +180,7 @@ static PyTypeObject CheckType = {
     0,                                                              /*tp_getattro*/
     0,                                                              /*tp_setattro*/
     0,                                                              /*tp_as_buffer*/
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,                        /*tp_flags*/
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HAVE_GC,  /*tp_flags*/
     0,                                                              /*tp_doc*/
     (traverseproc)Check_tp_traverse,                                /*tp_traverse*/
     (inquiry)Check_tp_clear,                                        /*tp_clear*/

--- a/src/fs.c
+++ b/src/fs.c
@@ -2621,7 +2621,7 @@ static PyTypeObject FSEventType = {
     0,                                                              /*tp_getattro*/
     0,                                                              /*tp_setattro*/
     0,                                                              /*tp_as_buffer*/
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,                        /*tp_flags*/
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HAVE_GC,  /*tp_flags*/
     0,                                                              /*tp_doc*/
     (traverseproc)FSEvent_tp_traverse,                              /*tp_traverse*/
     (inquiry)FSEvent_tp_clear,                                      /*tp_clear*/
@@ -2862,7 +2862,7 @@ static PyTypeObject FSPollType = {
     0,                                                              /*tp_getattro*/
     0,                                                              /*tp_setattro*/
     0,                                                              /*tp_as_buffer*/
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,                        /*tp_flags*/
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HAVE_GC,  /*tp_flags*/
     0,                                                              /*tp_doc*/
     (traverseproc)FSPoll_tp_traverse,                               /*tp_traverse*/
     (inquiry)FSPoll_tp_clear,                                       /*tp_clear*/

--- a/src/handle.c
+++ b/src/handle.c
@@ -246,7 +246,7 @@ static PyTypeObject HandleType = {
     0,                                                             /*tp_getattro*/
     0,                                                             /*tp_setattro*/
     0,                                                             /*tp_as_buffer*/
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,                       /*tp_flags*/
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HAVE_GC, /*tp_flags*/
     0,                                                             /*tp_doc*/
     (traverseproc)Handle_tp_traverse,                              /*tp_traverse*/
     (inquiry)Handle_tp_clear,                                      /*tp_clear*/

--- a/src/idle.c
+++ b/src/idle.c
@@ -180,7 +180,7 @@ static PyTypeObject IdleType = {
     0,                                                              /*tp_getattro*/
     0,                                                              /*tp_setattro*/
     0,                                                              /*tp_as_buffer*/
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,                        /*tp_flags*/
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HAVE_GC,  /*tp_flags*/
     0,                                                              /*tp_doc*/
     (traverseproc)Idle_tp_traverse,                                 /*tp_traverse*/
     (inquiry)Idle_tp_clear,                                         /*tp_clear*/

--- a/src/loop.c
+++ b/src/loop.c
@@ -313,7 +313,7 @@ static PyTypeObject LoopType = {
     0,                                                              /*tp_getattro*/
     0,                                                              /*tp_setattro*/
     0,                                                              /*tp_as_buffer*/
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,                        /*tp_flags*/
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HAVE_GC,  /*tp_flags*/
     0,                                                              /*tp_doc*/
     (traverseproc)Loop_tp_traverse,                                 /*tp_traverse*/
     (inquiry)Loop_tp_clear,                                         /*tp_clear*/

--- a/src/pipe.c
+++ b/src/pipe.c
@@ -463,7 +463,7 @@ static PyTypeObject PipeType = {
     0,                                                             /*tp_getattro*/
     0,                                                             /*tp_setattro*/
     0,                                                             /*tp_as_buffer*/
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,                       /*tp_flags*/
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HAVE_GC, /*tp_flags*/
     0,                                                             /*tp_doc*/
     (traverseproc)Pipe_tp_traverse,                                /*tp_traverse*/
     (inquiry)Pipe_tp_clear,                                        /*tp_clear*/

--- a/src/poll.c
+++ b/src/poll.c
@@ -194,7 +194,7 @@ static PyTypeObject PollType = {
     0,                                                              /*tp_getattro*/
     0,                                                              /*tp_setattro*/
     0,                                                              /*tp_as_buffer*/
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,                        /*tp_flags*/
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HAVE_GC,  /*tp_flags*/
     0,                                                              /*tp_doc*/
     (traverseproc)Poll_tp_traverse,                                 /*tp_traverse*/
     (inquiry)Poll_tp_clear,                                         /*tp_clear*/

--- a/src/prepare.c
+++ b/src/prepare.c
@@ -180,7 +180,7 @@ static PyTypeObject PrepareType = {
     0,                                                              /*tp_getattro*/
     0,                                                              /*tp_setattro*/
     0,                                                              /*tp_as_buffer*/
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,                        /*tp_flags*/
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HAVE_GC,  /*tp_flags*/
     0,                                                              /*tp_doc*/
     (traverseproc)Prepare_tp_traverse,                              /*tp_traverse*/
     (inquiry)Prepare_tp_clear,                                      /*tp_clear*/

--- a/src/process.c
+++ b/src/process.c
@@ -145,7 +145,7 @@ static PyTypeObject StdIOType = {
     0,                                                              /*tp_getattro*/
     0,                                                              /*tp_setattro*/
     0,                                                              /*tp_as_buffer*/
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,                        /*tp_flags*/
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HAVE_GC,  /*tp_flags*/
     0,                                                              /*tp_doc*/
     (traverseproc)StdIO_tp_traverse,                                /*tp_traverse*/
     (inquiry)StdIO_tp_clear,                                        /*tp_clear*/
@@ -571,7 +571,7 @@ static PyTypeObject ProcessType = {
     0,                                                              /*tp_getattro*/
     0,                                                              /*tp_setattro*/
     0,                                                              /*tp_as_buffer*/
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,                        /*tp_flags*/
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HAVE_GC,  /*tp_flags*/
     0,                                                              /*tp_doc*/
     (traverseproc)Process_tp_traverse,                              /*tp_traverse*/
     (inquiry)Process_tp_clear,                                      /*tp_clear*/

--- a/src/signal.c
+++ b/src/signal.c
@@ -176,7 +176,7 @@ static PyTypeObject SignalType = {
     0,                                                              /*tp_getattro*/
     0,                                                              /*tp_setattro*/
     0,                                                              /*tp_as_buffer*/
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,                        /*tp_flags*/
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HAVE_GC,  /*tp_flags*/
     0,                                                              /*tp_doc*/
     (traverseproc)Signal_tp_traverse,                               /*tp_traverse*/
     (inquiry)Signal_tp_clear,                                       /*tp_clear*/
@@ -509,7 +509,7 @@ static PyTypeObject SignalCheckerType = {
     0,                                                              /*tp_getattro*/
     0,                                                              /*tp_setattro*/
     0,                                                              /*tp_as_buffer*/
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,                        /*tp_flags*/
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HAVE_GC,  /*tp_flags*/
     0,                                                              /*tp_doc*/
     (traverseproc)SignalChecker_tp_traverse,                        /*tp_traverse*/
     (inquiry)SignalChecker_tp_clear,                                /*tp_clear*/

--- a/src/stream.c
+++ b/src/stream.c
@@ -459,7 +459,7 @@ static PyTypeObject StreamType = {
     0,                                                             /*tp_getattro*/
     0,                                                             /*tp_setattro*/
     0,                                                             /*tp_as_buffer*/
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,                       /*tp_flags*/
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HAVE_GC, /*tp_flags*/
     0,                                                             /*tp_doc*/
     (traverseproc)Stream_tp_traverse,                              /*tp_traverse*/
     (inquiry)Stream_tp_clear,                                      /*tp_clear*/

--- a/src/tcp.c
+++ b/src/tcp.c
@@ -502,7 +502,7 @@ static PyTypeObject TCPType = {
     0,                                                             /*tp_getattro*/
     0,                                                             /*tp_setattro*/
     0,                                                             /*tp_as_buffer*/
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,                       /*tp_flags*/
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HAVE_GC, /*tp_flags*/
     0,                                                             /*tp_doc*/
     (traverseproc)TCP_tp_traverse,                                 /*tp_traverse*/
     (inquiry)TCP_tp_clear,                                         /*tp_clear*/

--- a/src/thread.c
+++ b/src/thread.c
@@ -105,7 +105,7 @@ static PyTypeObject BarrierType = {
     0,                                                              /*tp_getattro*/
     0,                                                              /*tp_setattro*/
     0,                                                              /*tp_as_buffer*/
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,                        /*tp_flags*/
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HAVE_GC,  /*tp_flags*/
     0,                                                              /*tp_doc*/
     (traverseproc)Barrier_tp_traverse,                              /*tp_traverse*/
     (inquiry)Barrier_tp_clear,                                      /*tp_clear*/
@@ -257,7 +257,7 @@ static PyTypeObject MutexType = {
     0,                                                              /*tp_getattro*/
     0,                                                              /*tp_setattro*/
     0,                                                              /*tp_as_buffer*/
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,                        /*tp_flags*/
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HAVE_GC,  /*tp_flags*/
     0,                                                              /*tp_doc*/
     (traverseproc)Mutex_tp_traverse,                                /*tp_traverse*/
     (inquiry)Mutex_tp_clear,                                        /*tp_clear*/
@@ -445,7 +445,7 @@ static PyTypeObject RWLockType = {
     0,                                                              /*tp_getattro*/
     0,                                                              /*tp_setattro*/
     0,                                                              /*tp_as_buffer*/
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,                        /*tp_flags*/
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HAVE_GC,  /*tp_flags*/
     0,                                                              /*tp_doc*/
     (traverseproc)RWLock_tp_traverse,                               /*tp_traverse*/
     (inquiry)RWLock_tp_clear,                                       /*tp_clear*/
@@ -625,7 +625,7 @@ static PyTypeObject ConditionType = {
     0,                                                              /*tp_getattro*/
     0,                                                              /*tp_setattro*/
     0,                                                              /*tp_as_buffer*/
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,                        /*tp_flags*/
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HAVE_GC,  /*tp_flags*/
     0,                                                              /*tp_doc*/
     (traverseproc)Condition_tp_traverse,                            /*tp_traverse*/
     (inquiry)Condition_tp_clear,                                    /*tp_clear*/
@@ -781,7 +781,7 @@ static PyTypeObject SemaphoreType = {
     0,                                                              /*tp_getattro*/
     0,                                                              /*tp_setattro*/
     0,                                                              /*tp_as_buffer*/
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,                        /*tp_flags*/
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HAVE_GC,  /*tp_flags*/
     0,                                                              /*tp_doc*/
     (traverseproc)Semaphore_tp_traverse,                            /*tp_traverse*/
     (inquiry)Semaphore_tp_clear,                                    /*tp_clear*/

--- a/src/threadpool.c
+++ b/src/threadpool.c
@@ -244,7 +244,7 @@ static PyTypeObject ThreadPoolType = {
     0,                                                              /*tp_getattro*/
     0,                                                              /*tp_setattro*/
     0,                                                              /*tp_as_buffer*/
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,                        /*tp_flags*/
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HAVE_GC,  /*tp_flags*/
     0,                                                              /*tp_doc*/
     (traverseproc)ThreadPool_tp_traverse,                           /*tp_traverse*/
     (inquiry)ThreadPool_tp_clear,                                   /*tp_clear*/

--- a/src/timer.c
+++ b/src/timer.c
@@ -253,7 +253,7 @@ static PyTypeObject TimerType = {
     0,                                                              /*tp_getattro*/
     0,                                                              /*tp_setattro*/
     0,                                                              /*tp_as_buffer*/
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,                        /*tp_flags*/
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HAVE_GC,  /*tp_flags*/
     0,                                                              /*tp_doc*/
     (traverseproc)Timer_tp_traverse,                                /*tp_traverse*/
     (inquiry)Timer_tp_clear,                                        /*tp_clear*/

--- a/src/tty.c
+++ b/src/tty.c
@@ -167,7 +167,7 @@ static PyTypeObject TTYType = {
     0,                                                             /*tp_getattro*/
     0,                                                             /*tp_setattro*/
     0,                                                             /*tp_as_buffer*/
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,                       /*tp_flags*/
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HAVE_GC, /*tp_flags*/
     0,                                                             /*tp_doc*/
     (traverseproc)TTY_tp_traverse,                                 /*tp_traverse*/
     (inquiry)TTY_tp_clear,                                         /*tp_clear*/

--- a/src/udp.c
+++ b/src/udp.c
@@ -679,7 +679,7 @@ static PyTypeObject UDPType = {
     0,                                                              /*tp_getattro*/
     0,                                                              /*tp_setattro*/
     0,                                                              /*tp_as_buffer*/
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,                        /*tp_flags*/
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HAVE_GC,  /*tp_flags*/
     0,                                                              /*tp_doc*/
     (traverseproc)UDP_tp_traverse,                                  /*tp_traverse*/
     (inquiry)UDP_tp_clear,                                          /*tp_clear*/

--- a/tests/test_basetype.py
+++ b/tests/test_basetype.py
@@ -1,0 +1,109 @@
+
+from common import unittest2
+import sys
+import pyuv
+import pyuv.fs
+import pyuv.thread
+import tempfile
+import os
+
+
+class TestBasetype(unittest2.TestCase):
+
+    def _inheritance_test(self, base, *args, **kwargs):
+        derived = type(base.__name__, (base,), {})
+        assert derived is not base
+        assert issubclass(derived, base)
+        instance = derived(*args, **kwargs)
+        assert isinstance(instance, base)
+        assert isinstance(instance, derived)
+
+    def test_inherit_loop(self):
+        self._inheritance_test(pyuv.Loop)
+
+    def test_inherit_timer(self):
+        loop = pyuv.Loop.default_loop()
+        self._inheritance_test(pyuv.Timer, loop)
+
+    def test_inherit_tcp(self):
+        loop = pyuv.Loop.default_loop()
+        self._inheritance_test(pyuv.TCP, loop)
+
+    def test_inherit_udp(self):
+        loop = pyuv.Loop.default_loop()
+        self._inheritance_test(pyuv.UDP, loop)
+
+    def test_inherit_poll(self):
+        loop = pyuv.Loop.default_loop()
+        fd, fname = tempfile.mkstemp()
+        os.unlink(fname)
+        self._inheritance_test(pyuv.Poll, loop, fd)
+
+    def test_inherit_pipe(self):
+        loop = pyuv.Loop.default_loop()
+        self._inheritance_test(pyuv.Pipe, loop)
+
+    def test_inherit_tty(self):
+        loop = pyuv.Loop.default_loop()
+        fd, fname = tempfile.mkstemp()
+        os.unlink(fname)
+        self._inheritance_test(pyuv.TTY, loop, fd, False)
+
+    def test_inherit_threadpool(self):
+        loop = pyuv.Loop.default_loop()
+        self._inheritance_test(pyuv.ThreadPool, loop)
+
+    def test_inherit_process(self):
+        loop = pyuv.Loop.default_loop()
+        self._inheritance_test(pyuv.Process, loop)
+
+    def test_inherit_stdio(self):
+        self._inheritance_test(pyuv.StdIO, fd=sys.stdin.fileno())
+
+    def test_inherit_async(self):
+        loop = pyuv.Loop.default_loop()
+        callback = lambda handle: handle
+        self._inheritance_test(pyuv.Async, loop, callback)
+
+    def test_inherit_prepare(self):
+        loop = pyuv.Loop.default_loop()
+        self._inheritance_test(pyuv.Prepare, loop)
+
+    def test_inherit_idle(self):
+        loop = pyuv.Loop.default_loop()
+        self._inheritance_test(pyuv.Idle, loop)
+
+    def test_inherit_check(self):
+        loop = pyuv.Loop.default_loop()
+        self._inheritance_test(pyuv.Check, loop)
+
+    def test_inherit_signal(self):
+        loop = pyuv.Loop.default_loop()
+        self._inheritance_test(pyuv.Signal, loop)
+
+    def test_inherit_signalchecker(self):
+        loop = pyuv.Loop.default_loop()
+        self._inheritance_test(pyuv.SignalChecker, loop)
+
+    def test_inherit_fs_fsevent(self):
+        loop = pyuv.Loop.default_loop()
+        self._inheritance_test(pyuv.fs.FSEvent, loop)
+
+    def test_inherit_fs_fspoll(self):
+        loop = pyuv.Loop.default_loop()
+        self._inheritance_test(pyuv.fs.FSEvent, loop)
+
+    def test_inherit_thread_barrier(self):
+        self._inheritance_test(pyuv.thread.Barrier, 1)
+
+    def test_inherit_thread_condition(self):
+        self._inheritance_test(pyuv.thread.Condition)
+
+    def test_inherit_thread_mutex(self):
+        self._inheritance_test(pyuv.thread.Mutex)
+
+    def test_inherit_thread_rwlock(self):
+        self._inheritance_test(pyuv.thread.RWLock)
+
+    def test_inherit_thread_semaphore(self):
+        self._inheritance_test(pyuv.thread.Semaphore, 1)


### PR DESCRIPTION
Add `Py_TPFLAGS_BASETYPE` to the `tp_flags` member for extension types. This changes allows them to be used as a base class.
