### PR TITLE
Fix Python 3 compatibility

### DIFF
--- a/setup_libuv.py
+++ b/setup_libuv.py
@@ -1,3 +1,4 @@
+
 import errno
 import os
 import shutil


### PR DESCRIPTION
This is a partially fix for #66 because any error message while executing `vcbuild.bat` now gets properly reported (on Python 2 and Python 3).
