### PR TITLE
Fix setup workflow for libuv

### DIFF
--- a/setup_libuv.py
+++ b/setup_libuv.py
@@ -124,7 +124,11 @@ class libuv_build_ext(build_ext):
         if self.libuv_force_fetch:
             rmtree('deps')
         if not os.path.exists(self.libuv_dir):
-            download_libuv()
+            try:
+                download_libuv()
+            except BaseException:
+                rmtree('deps')
+                raise
             patch_libuv()
             build_libuv()
         else:


### PR DESCRIPTION
If libuv cannot be downloaded because git is missing, the setup
will leave the empty _deps_ directory. This will break the following
build even if the user has installed git in the meantime, because
the setup routine assumes that libuv is already downloaded.

With this patch the "deps" directory will be deleted if the download
of libuv fails, leaving pyuv in a clean state where the second 
setup approach will succeed if the git dependency is resolved.
