### PR TITLE
Fixes miscalculation of struct sizes

### DIFF
--- a/setup_libuv.py
+++ b/setup_libuv.py
@@ -130,8 +130,8 @@ class libuv_build_ext(build_ext):
         elif sys.platform == 'darwin':
             self.extensions[0].extra_link_args.extend(['-framework', 'CoreServices'])
         elif sys.platform == 'win32':
+            self.extensions[0].define_macros.append(('WIN32', 1))
             if self.compiler.compiler_type == 'msvc':
-                self.extensions[0].extra_compile_args.extend(['/D', '"WIN32"'])
                 self.extensions[0].extra_link_args.extend(['/NODEFAULTLIB:libcmt', '/LTCG'])
                 self.compiler.add_library('advapi32')
             self.compiler.add_library('iphlpapi')

--- a/tests/test_basetype.py
+++ b/tests/test_basetype.py
@@ -1,5 +1,5 @@
 
-from common import unittest2, platform_skip
+from common import unittest2
 
 import pyuv
 import socket
@@ -30,7 +30,6 @@ class TestBasetype(unittest2.TestCase):
         loop = pyuv.Loop.default_loop()
         self._inheritance_test(pyuv.UDP, loop)
 
-    @platform_skip(["win32"])
     def test_inherit_poll(self):
         loop = pyuv.Loop.default_loop()
         sock = socket.socket()

--- a/tests/test_poll.py
+++ b/tests/test_poll.py
@@ -1,6 +1,6 @@
 
-from common import unittest2, platform_skip, linesep
-
+from common import unittest2
+import common
 import errno
 import pyuv
 import socket
@@ -14,8 +14,6 @@ if sys.platform == "win32":
 else:
     NONBLOCKING = (errno.EAGAIN, errno.EINPROGRESS, errno.EWOULDBLOCK)
 
-
-@platform_skip(["win32"])
 class PollTest(unittest2.TestCase):
 
     def setUp(self):
@@ -32,10 +30,10 @@ class PollTest(unittest2.TestCase):
         server.accept(client)
         self.client_connection = client
         client.start_read(self.on_client_connection_read)
-        client.write(b"PING"+linesep)
+        client.write(b"PING"+common.linesep)
 
     def on_client_connection_read(self, client, data, error):
-        self.assertEqual(data, b"PONG"+linesep)
+        self.assertEqual(data, b"PONG"+common.linesep)
         self.poll.close()
         self.client_connection.close()
         self.server.close()
@@ -62,11 +60,11 @@ class PollTest(unittest2.TestCase):
         if (events & pyuv.UV_READABLE):
             self.poll.stop()
             data = self.sock.recv(1024)
-            self.assertEqual(data, b"PING"+linesep)
+            self.assertEqual(data, b"PING"+common.linesep)
             self.poll.start(pyuv.UV_WRITABLE, self.poll_cb)
         elif (events & pyuv.UV_WRITABLE):
             self.poll.stop()
-            self.sock.send(b"PONG"+linesep)
+            self.sock.send(b"PONG"+common.linesep)
 
     def test_poll(self):
         self.server = pyuv.TCP(self.loop)


### PR DESCRIPTION
Oh no, I was already going in the right direction with #91. I just identified the wrong precompiler flag back there because of the strange behavior of `faulthandler`.

However, passing `WIN32` as precompiler flag will fix the miscalculation of struct sizes identified in #92.
