### PR TITLE
Re-raise exceptions from callbacks when exiting Loop.run().

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -2,6 +2,7 @@
 import os
 import sys
 sys.path.insert(0, '../')
+import pyuv
 
 
 if sys.version_info < (2, 7) or (0x03000000 <= sys.hexversion < 0x03010000):
@@ -11,10 +12,21 @@ else:
     import unittest as unittest2
 
 
-if sys.version_info >= (3, 0):
+if sys.version_info >= (3,):
     linesep = os.linesep.encode()
+
+    def reraise(typ, value, tb):
+        if value.__traceback__ is not tb:
+            raise value.with_traceback(tb)
+        raise value
+
 else:
     linesep = os.linesep
+
+    exec("""\
+def reraise(typ, value, tb):
+    raise typ, value, tb
+""")
 
 
 platform = 'linux' if sys.platform.startswith('linux') else sys.platform
@@ -28,3 +40,35 @@ def platform_skip(platform_list):
     return _noop
 
 
+class TestLoop(pyuv.Loop):
+
+    def __init__(self):
+        super(TestLoop, self).__init__()
+        self.excepthook = self._handle_exception_in_callback
+
+    def run(self, *args, **kwargs):
+        self._callback_exc_info = None
+        super(TestLoop, self).run(*args, **kwargs)
+        self._reraise()
+
+    def walk(self, *args, **kwargs):
+        self._callback_exc_info = None
+        super(TestLoop, self).walk(*args, **kwargs)
+        self._reraise()
+
+    def _handle_exception_in_callback(self, typ, value, tb):
+        if self._callback_exc_info is None:
+            self._callback_exc_info = typ, value, tb
+            self.stop()
+
+    def _reraise(self):
+        if self._callback_exc_info is not None:
+            typ, value, tb = self._callback_exc_info
+            self._callback_exc_info = None
+            reraise(typ, value, tb)
+
+
+class TestCase(unittest2.TestCase):
+
+    def setUp(self):
+        self.loop = TestLoop()

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -1,11 +1,11 @@
 
 import threading
 
-from common import unittest2
+from common import unittest2, TestCase
 import pyuv
 
 
-class AsyncTest(unittest2.TestCase):
+class AsyncTest(TestCase):
 
     def test_async1(self):
         self.async_cb_called = 0
@@ -30,7 +30,6 @@ class AsyncTest(unittest2.TestCase):
                     if n == 3:
                         break
                     self.async.send()
-        self.loop = pyuv.Loop.default_loop()
         self.async = pyuv.Async(self.loop, async_cb)
         self.prepare = pyuv.Prepare(self.loop)
         self.prepare.start(prepare_cb)
@@ -42,4 +41,3 @@ class AsyncTest(unittest2.TestCase):
 
 if __name__ == '__main__':
     unittest2.main(verbosity=2)
-

--- a/tests/test_basetype.py
+++ b/tests/test_basetype.py
@@ -1,11 +1,11 @@
 
-from common import unittest2
+from common import unittest2, TestCase
 
 import pyuv
 import socket
 
 
-class TestBasetype(unittest2.TestCase):
+class TestBasetype(TestCase):
 
     def _inheritance_test(self, base, *args, **kwargs):
         derived = type(base.__name__, (base,), {})
@@ -19,55 +19,43 @@ class TestBasetype(unittest2.TestCase):
         self._inheritance_test(pyuv.Loop)
 
     def test_inherit_timer(self):
-        loop = pyuv.Loop.default_loop()
-        self._inheritance_test(pyuv.Timer, loop)
+        self._inheritance_test(pyuv.Timer, self.loop)
 
     def test_inherit_tcp(self):
-        loop = pyuv.Loop.default_loop()
-        self._inheritance_test(pyuv.TCP, loop)
+        self._inheritance_test(pyuv.TCP, self.loop)
 
     def test_inherit_udp(self):
-        loop = pyuv.Loop.default_loop()
-        self._inheritance_test(pyuv.UDP, loop)
+        self._inheritance_test(pyuv.UDP, self.loop)
 
     def test_inherit_poll(self):
-        loop = pyuv.Loop.default_loop()
         sock = socket.socket()
-        self._inheritance_test(pyuv.Poll, loop, sock.fileno())
+        self._inheritance_test(pyuv.Poll, self.loop, sock.fileno())
         sock.close()
 
     def test_inherit_pipe(self):
-        loop = pyuv.Loop.default_loop()
-        self._inheritance_test(pyuv.Pipe, loop)
+        self._inheritance_test(pyuv.Pipe, self.loop)
 
     def test_inherit_process(self):
-        loop = pyuv.Loop.default_loop()
-        self._inheritance_test(pyuv.Process, loop)
+        self._inheritance_test(pyuv.Process, self.loop)
 
     def test_inherit_async(self):
-        loop = pyuv.Loop.default_loop()
         callback = lambda handle: handle
-        self._inheritance_test(pyuv.Async, loop, callback)
+        self._inheritance_test(pyuv.Async, self.loop, callback)
 
     def test_inherit_prepare(self):
-        loop = pyuv.Loop.default_loop()
-        self._inheritance_test(pyuv.Prepare, loop)
+        self._inheritance_test(pyuv.Prepare, self.loop)
 
     def test_inherit_idle(self):
-        loop = pyuv.Loop.default_loop()
-        self._inheritance_test(pyuv.Idle, loop)
+        self._inheritance_test(pyuv.Idle, self.loop)
 
     def test_inherit_check(self):
-        loop = pyuv.Loop.default_loop()
-        self._inheritance_test(pyuv.Check, loop)
+        self._inheritance_test(pyuv.Check, self.loop)
 
     def test_inherit_signal(self):
-        loop = pyuv.Loop.default_loop()
-        self._inheritance_test(pyuv.Signal, loop)
+        self._inheritance_test(pyuv.Signal, self.loop)
 
     def test_inherit_fs_fspoll(self):
-        loop = pyuv.Loop.default_loop()
-        self._inheritance_test(pyuv.fs.FSPoll, loop)
+        self._inheritance_test(pyuv.fs.FSPoll, self.loop)
 
     def test_inherit_thread_barrier(self):
         self._inheritance_test(pyuv.thread.Barrier, 1)
@@ -87,4 +75,3 @@ class TestBasetype(unittest2.TestCase):
 
 if __name__ == '__main__':
     unittest2.main(verbosity=2)
-

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -1,9 +1,9 @@
 
-from common import unittest2
+from common import unittest2, TestCase
 import pyuv
 
 
-class CheckTest(unittest2.TestCase):
+class CheckTest(TestCase):
 
     def test_check1(self):
         self.check_cb_called = 0
@@ -16,15 +16,13 @@ class CheckTest(unittest2.TestCase):
             self.timer_cb_called += 1
             timer.stop()
             timer.close()
-        loop = pyuv.Loop.default_loop()
-        check = pyuv.Check(loop)
+        check = pyuv.Check(self.loop)
         check.start(check_cb)
-        timer = pyuv.Timer(loop)
+        timer = pyuv.Timer(self.loop)
         timer.start(timer_cb, 0.1, 0)
-        loop.run()
+        self.loop.run()
         self.assertEqual(self.check_cb_called, 1)
 
 
 if __name__ == '__main__':
     unittest2.main(verbosity=2)
-

--- a/tests/test_gc.py
+++ b/tests/test_gc.py
@@ -2,17 +2,16 @@
 import gc
 import weakref
 
-from common import unittest2
+from common import unittest2, TestCase
 import pyuv
 
 
 class Foo(object): pass
 
-class GCTest(unittest2.TestCase):
+class GCTest(TestCase):
 
     def test_gc(self):
-        loop = pyuv.Loop.default_loop()
-        timer = pyuv.Timer(loop)
+        timer = pyuv.Timer(self.loop)
 
         w_timer = weakref.ref(timer)
         self.assertNotEqual(w_timer(), None)
@@ -30,4 +29,3 @@ class GCTest(unittest2.TestCase):
 
 if __name__ == '__main__':
     unittest2.main(verbosity=2)
-

--- a/tests/test_idle.py
+++ b/tests/test_idle.py
@@ -1,9 +1,9 @@
 
-from common import unittest2
+from common import unittest2, TestCase
 import pyuv
 
 
-class IdleTest(unittest2.TestCase):
+class IdleTest(TestCase):
 
     def test_idle1(self):
         self.idle_cb_called = 0
@@ -11,13 +11,11 @@ class IdleTest(unittest2.TestCase):
             self.idle_cb_called += 1
             idle.stop()
             idle.close()
-        loop = pyuv.Loop.default_loop()
-        idle = pyuv.Idle(loop)
+        idle = pyuv.Idle(self.loop)
         idle.start(idle_cb)
-        loop.run()
+        self.loop.run()
         self.assertEqual(self.idle_cb_called, 1)
 
 
 if __name__ == '__main__':
     unittest2.main(verbosity=2)
-

--- a/tests/test_ipc.py
+++ b/tests/test_ipc.py
@@ -1,5 +1,5 @@
 
-from common import unittest2, platform_skip
+from common import unittest2, platform_skip, TestCase
 from functools import partial
 
 import pyuv
@@ -18,10 +18,7 @@ else:
     TEST_PIPE = 'test-pipe'
 
 
-class IPCTest(unittest2.TestCase):
-
-    def setUp(self):
-        self.loop = pyuv.Loop.default_loop()
+class IPCTest(TestCase):
 
     def proc_exit_cb(self, proc, exit_status, term_signal):
         proc.close()
@@ -77,10 +74,7 @@ class IPCTest(unittest2.TestCase):
         self._do_test("listen_after_write")
 
 
-class IPCSendRecvTest(unittest2.TestCase):
-
-    def setUp(self):
-        self.loop = pyuv.Loop.default_loop()
+class IPCSendRecvTest(TestCase):
 
     def proc_exit_cb(self, proc, exit_status, term_signal):
         proc.close()

--- a/tests/test_loop_run.py
+++ b/tests/test_loop_run.py
@@ -1,20 +1,19 @@
 
-from common import unittest2
+from common import unittest2, TestCase
 import pyuv
 
 
-class LoopRunTest(unittest2.TestCase):
+class LoopRunTest(TestCase):
 
     def test_run_once(self):
         self.cb_called = 0
         def prepare_cb(handle):
             handle.close()
             self.cb_called += 1
-        loop = pyuv.Loop.default_loop()
         for i in range(500):
-            prepare = pyuv.Prepare(loop)
+            prepare = pyuv.Prepare(self.loop)
             prepare.start(prepare_cb)
-            loop.run(pyuv.UV_RUN_ONCE)
+            self.loop.run(pyuv.UV_RUN_ONCE)
         self.assertEqual(self.cb_called, 500)
 
     def test_run_nowait(self):
@@ -22,10 +21,9 @@ class LoopRunTest(unittest2.TestCase):
         def timer_cb(handle):
             handle.close()
             self.cb_called = 1
-        loop = pyuv.Loop.default_loop()
-        timer = pyuv.Timer(loop)
+        timer = pyuv.Timer(self.loop)
         timer.start(timer_cb, 10, 10)
-        loop.run(pyuv.UV_RUN_NOWAIT)
+        self.loop.run(pyuv.UV_RUN_NOWAIT)
         self.assertEqual(self.cb_called, 0)
 
     def test_stop(self):
@@ -42,7 +40,6 @@ class LoopRunTest(unittest2.TestCase):
             self.prepare_called += 1
             if self.prepare_called == self.num_ticks:
                 handle.close()
-        self.loop = pyuv.Loop.default_loop()
         timer = pyuv.Timer(self.loop)
         timer.start(timer_cb, 0.1, 0.1)
         prepare = pyuv.Prepare(self.loop)
@@ -59,4 +56,3 @@ class LoopRunTest(unittest2.TestCase):
 
 if __name__ == '__main__':
     unittest2.main(verbosity=2)
-

--- a/tests/test_multihandles.py
+++ b/tests/test_multihandles.py
@@ -1,9 +1,9 @@
 
-from common import unittest2
+from common import unittest2, TestCase
 import pyuv
 
 
-class MultiHandleTest(unittest2.TestCase):
+class MultiHandleTest(TestCase):
 
     def test_multihandle1(self):
         self.close_cb_called = 0
@@ -29,16 +29,15 @@ class MultiHandleTest(unittest2.TestCase):
             self.timer_cb_called += 1
             timer.stop()
             timer.close(close_cb)
-        loop = pyuv.Loop.default_loop()
-        prepare = pyuv.Prepare(loop)
+        prepare = pyuv.Prepare(self.loop)
         prepare.start(prepare_cb)
-        idle = pyuv.Idle(loop)
+        idle = pyuv.Idle(self.loop)
         idle.start(idle_cb)
-        check = pyuv.Check(loop)
+        check = pyuv.Check(self.loop)
         check.start(check_cb)
-        timer = pyuv.Timer(loop)
+        timer = pyuv.Timer(self.loop)
         timer.start(timer_cb, 0.1, 0)
-        loop.run()
+        self.loop.run()
         self.assertEqual(self.prepare_cb_called, 1)
         self.assertEqual(self.idle_cb_called, 1)
         self.assertEqual(self.check_cb_called, 1)
@@ -47,4 +46,3 @@ class MultiHandleTest(unittest2.TestCase):
 
 if __name__ == '__main__':
     unittest2.main(verbosity=2)
-

--- a/tests/test_pipe.py
+++ b/tests/test_pipe.py
@@ -1,8 +1,7 @@
 
 import sys
 
-from common import unittest2, platform_skip
-import common
+from common import unittest2, linesep, platform_skip, TestCase
 import pyuv
 
 if sys.platform == 'win32':
@@ -13,33 +12,35 @@ else:
 BAD_PIPE = '/pipe/that/does/not/exist'
 
 
-class PipeErrorTest(unittest2.TestCase):
+class PipeErrorTest(TestCase):
 
     def on_client_connect_error(self, client_pipe, error):
         self.assertNotEqual(error, None)
         client_pipe.close()
 
     def test_client1(self):
-        loop = pyuv.Loop.default_loop()
-        client = pyuv.Pipe(loop)
+        client = pyuv.Pipe(self.loop)
         client.connect(BAD_PIPE, self.on_client_connect_error)
-        loop.run()
+        self.loop.run()
 
 
-class PipeTest(unittest2.TestCase):
+class PipeTestCase(TestCase):
 
     def setUp(self):
-        self.loop = pyuv.Loop.default_loop()
+        super(PipeTestCase, self).setUp()
         self.server = None
         self.client = None
         self.client_connections = []
+
+
+class PipeTest(PipeTestCase):
 
     def on_connection(self, server, error):
         client = pyuv.Pipe(self.loop)
         server.accept(client)
         self.client_connections.append(client)
         client.start_read(self.on_client_connection_read)
-        client.write(b"PING"+common.linesep)
+        client.write(b"PING"+linesep)
 
     def on_client_connection_read(self, client, data, error):
         if data is None:
@@ -68,20 +69,14 @@ class PipeTest(unittest2.TestCase):
         self.loop.run()
 
 
-class PipeTestNull(unittest2.TestCase):
-
-    def setUp(self):
-        self.loop = pyuv.Loop.default_loop()
-        self.server = None
-        self.client = None
-        self.client_connections = []
+class PipeTestNull(PipeTestCase):
 
     def on_connection(self, server, error):
         client = pyuv.Pipe(self.loop)
         server.accept(client)
         self.client_connections.append(client)
         client.start_read(self.on_client_connection_read)
-        client.write(b"PIN\x00G"+common.linesep)
+        client.write(b"PIN\x00G"+linesep)
 
     def on_client_connection_read(self, client, data, error):
         if data is None:
@@ -111,20 +106,14 @@ class PipeTestNull(unittest2.TestCase):
 
 
 @platform_skip(["win32"])
-class PipeTestList(unittest2.TestCase):
-
-    def setUp(self):
-        self.loop = pyuv.Loop.default_loop()
-        self.server = None
-        self.client = None
-        self.client_connections = []
+class PipeTestList(PipeTestCase):
 
     def on_connection(self, server, error):
         client = pyuv.Pipe(self.loop)
         server.accept(client)
         self.client_connections.append(client)
         client.start_read(self.on_client_connection_read)
-        client.writelines([b"PING", common.linesep])
+        client.writelines([b"PING", linesep])
 
     def on_client_connection_read(self, client, data, error):
         if data is None:
@@ -139,7 +128,7 @@ class PipeTestList(unittest2.TestCase):
 
     def on_client_read(self, client, data, error):
         self.assertNotEqual(data, None)
-        self.assertEqual(data, b"PING"+common.linesep)
+        self.assertEqual(data, b"PING"+linesep)
         client.close()
 
     def test_pipe_list(self):
@@ -153,20 +142,14 @@ class PipeTestList(unittest2.TestCase):
 
 
 @platform_skip(["win32"])
-class PipeTestListNull(unittest2.TestCase):
-
-    def setUp(self):
-        self.loop = pyuv.Loop.default_loop()
-        self.server = None
-        self.client = None
-        self.client_connections = []
+class PipeTestListNull(PipeTestCase):
 
     def on_connection(self, server, error):
         client = pyuv.Pipe(self.loop)
         server.accept(client)
         self.client_connections.append(client)
         client.start_read(self.on_client_connection_read)
-        client.writelines([b"PING", b"\x00", common.linesep])
+        client.writelines([b"PING", b"\x00", linesep])
 
     def on_client_connection_read(self, client, data, error):
         if data is None:
@@ -181,7 +164,7 @@ class PipeTestListNull(unittest2.TestCase):
 
     def on_client_read(self, client, data, error):
         self.assertNotEqual(data, None)
-        self.assertEqual(data, b"PING\x00"+common.linesep)
+        self.assertEqual(data, b"PING\x00"+linesep)
         client.close()
 
     def test_pipe_list_null(self):
@@ -194,20 +177,14 @@ class PipeTestListNull(unittest2.TestCase):
         self.loop.run()
 
 
-class PipeShutdownTest(unittest2.TestCase):
-
-    def setUp(self):
-        self.loop = pyuv.Loop.default_loop()
-        self.server = None
-        self.client = None
-        self.client_connections = []
+class PipeShutdownTest(PipeTestCase):
 
     def on_connection(self, server, error):
         client = pyuv.Pipe(self.loop)
         server.accept(client)
         self.client_connections.append(client)
         client.start_read(self.on_client_connection_read)
-        client.write(b"PING"+common.linesep)
+        client.write(b"PING"+linesep)
 
     def on_client_connection_read(self, client, data, error):
         if data is None:
@@ -248,4 +225,3 @@ class PipeShutdownTest(unittest2.TestCase):
 
 if __name__ == '__main__':
     unittest2.main(verbosity=2)
-

--- a/tests/test_poll.py
+++ b/tests/test_poll.py
@@ -1,5 +1,5 @@
 
-from common import unittest2, linesep
+from common import unittest2, linesep, TestCase
 
 import errno
 import pyuv
@@ -15,10 +15,10 @@ else:
     NONBLOCKING = (errno.EAGAIN, errno.EINPROGRESS, errno.EWOULDBLOCK)
 
 
-class PollTest(unittest2.TestCase):
+class PollTest(TestCase):
 
     def setUp(self):
-        self.loop = pyuv.Loop.default_loop()
+        super(PollTest, self).setUp()
         self.poll = None
         self.server = None
         self.sock = None
@@ -27,7 +27,7 @@ class PollTest(unittest2.TestCase):
 
     def on_connection(self, server, error):
         self.assertEqual(error, None)
-        client = pyuv.TCP(pyuv.Loop.default_loop())
+        client = pyuv.TCP(self.loop)
         server.accept(client)
         self.client_connection = client
         client.start_read(self.on_client_connection_read)
@@ -38,10 +38,6 @@ class PollTest(unittest2.TestCase):
         self.poll.close()
         self.client_connection.close()
         self.server.close()
-
-    def on_client_connection(self, client, error):
-        self.assertEqual(error, None)
-        client.start_read(self.on_client_read)
 
     def poll_cb(self, handle, events, error):
         if self.connecting:
@@ -92,5 +88,3 @@ class PollTest(unittest2.TestCase):
 
 if __name__ == '__main__':
     unittest2.main(verbosity=2)
-
-

--- a/tests/test_prepare.py
+++ b/tests/test_prepare.py
@@ -1,9 +1,9 @@
 
-from common import unittest2
+from common import unittest2, TestCase
 import pyuv
 
 
-class PrepareTest(unittest2.TestCase):
+class PrepareTest(TestCase):
 
     def test_prepare1(self):
         self.prepare_cb_called = 0
@@ -11,13 +11,11 @@ class PrepareTest(unittest2.TestCase):
             self.prepare_cb_called += 1
             prepare.stop()
             prepare.close()
-        loop = pyuv.Loop.default_loop()
-        prepare = pyuv.Prepare(loop)
+        prepare = pyuv.Prepare(self.loop)
         prepare.start(prepare_cb)
-        loop.run()
+        self.loop.run()
         self.assertEqual(self.prepare_cb_called, 1)
 
 
 if __name__ == '__main__':
     unittest2.main(verbosity=2)
-

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -6,28 +6,26 @@ except ImportError:
     pwd = None
 import sys
 
-from common import platform_skip, unittest2
-import common
+from common import unittest2, linesep, platform_skip, TestCase
 import pyuv
 
 
-class ProcessTest(unittest2.TestCase):
+class ProcessTest(TestCase):
 
     def test_process_basic(self):
         self.exit_cb_called = 0
         self.close_cb_called = 0
         def proc_close_cb(proc):
-            self.close_cb_called +=1
+            self.close_cb_called += 1
         def proc_exit_cb(proc, exit_status, term_signal):
             self.assertEqual(exit_status, 0)
             self.exit_cb_called += 1
             proc.close(proc_close_cb)
-        loop = pyuv.Loop.default_loop()
-        proc = pyuv.Process(loop)
+        proc = pyuv.Process(self.loop)
         proc.spawn(file=sys.executable, args=["proc_basic.py"],
                    exit_callback=proc_exit_cb)
         pid = proc.pid
-        loop.run()
+        self.loop.run()
         self.assertEqual(self.exit_cb_called, 1)
         self.assertEqual(self.close_cb_called, 1)
         self.assertNotEqual(pid, None)
@@ -36,16 +34,15 @@ class ProcessTest(unittest2.TestCase):
         self.exit_cb_called = 0
         self.close_cb_called = 0
         def proc_close_cb(proc):
-            self.close_cb_called +=1
+            self.close_cb_called += 1
         def proc_exit_cb(proc, exit_status, term_signal):
             self.assertEqual(exit_status, 0)
             self.exit_cb_called += 1
             proc.close(proc_close_cb)
-        loop = pyuv.Loop.default_loop()
-        proc = pyuv.Process(loop)
+        proc = pyuv.Process(self.loop)
         proc.spawn(file=sys.executable, args=["proc_basic.py"],
                    exit_callback=proc_exit_cb, cwd=".")
-        loop.run()
+        self.loop.run()
         self.assertEqual(self.exit_cb_called, 1)
         self.assertEqual(self.close_cb_called, 1)
 
@@ -54,7 +51,7 @@ class ProcessTest(unittest2.TestCase):
         self.close_cb_called = 0
         self.received_output = None
         def handle_close_cb(handle):
-            self.close_cb_called +=1
+            self.close_cb_called += 1
         def proc_exit_cb(proc, exit_status, term_signal):
             self.assertEqual(exit_status, 0)
             self.exit_cb_called += 1
@@ -63,16 +60,15 @@ class ProcessTest(unittest2.TestCase):
             if data is not None:
                 self.received_output = data.strip()
             handle.close(handle_close_cb)
-        loop = pyuv.Loop.default_loop()
-        stdout_pipe = pyuv.Pipe(loop)
+        stdout_pipe = pyuv.Pipe(self.loop)
         stdio = []
         stdio.append(pyuv.StdIO(flags=pyuv.UV_IGNORE))
         stdio.append(pyuv.StdIO(stream=stdout_pipe, flags=pyuv.UV_CREATE_PIPE|pyuv.UV_WRITABLE_PIPE))
-        proc = pyuv.Process(loop)
+        proc = pyuv.Process(self.loop)
         proc.spawn(file=sys.executable, args=["proc_stdout.py"],
                    exit_callback=proc_exit_cb, stdio=stdio)
         stdout_pipe.start_read(stdout_read_cb)
-        loop.run()
+        self.loop.run()
         self.assertEqual(self.exit_cb_called, 1)
         self.assertEqual(self.close_cb_called, 2)
         self.assertEqual(self.received_output, b"TEST")
@@ -82,7 +78,7 @@ class ProcessTest(unittest2.TestCase):
         self.close_cb_called = 0
         self.received_output = None
         def handle_close_cb(handle):
-            self.close_cb_called +=1
+            self.close_cb_called += 1
         def proc_exit_cb(proc, exit_status, term_signal):
             self.assertEqual(exit_status, 0)
             self.exit_cb_called += 1
@@ -90,16 +86,15 @@ class ProcessTest(unittest2.TestCase):
         def stdout_read_cb(handle, data, error):
             self.received_output = data.strip()
             handle.close(handle_close_cb)
-        loop = pyuv.Loop.default_loop()
-        stdout_pipe = pyuv.Pipe(loop)
+        stdout_pipe = pyuv.Pipe(self.loop)
         stdio = []
         stdio.append(pyuv.StdIO(flags=pyuv.UV_IGNORE))
         stdio.append(pyuv.StdIO(stream=stdout_pipe, flags=pyuv.UV_CREATE_PIPE|pyuv.UV_WRITABLE_PIPE))
-        proc = pyuv.Process(loop)
+        proc = pyuv.Process(self.loop)
         proc.spawn(file=sys.executable, args=["proc_args_stdout.py", "TEST"],
                    exit_callback=proc_exit_cb, stdio=stdio)
         stdout_pipe.start_read(stdout_read_cb)
-        loop.run()
+        self.loop.run()
         self.assertEqual(self.exit_cb_called, 1)
         self.assertEqual(self.close_cb_called, 2)
         self.assertEqual(self.received_output, b"TEST")
@@ -109,7 +104,7 @@ class ProcessTest(unittest2.TestCase):
         self.close_cb_called = 0
         self.received_output = None
         def handle_close_cb(handle):
-            self.close_cb_called +=1
+            self.close_cb_called += 1
         def proc_exit_cb(proc, exit_status, term_signal):
             self.assertEqual(exit_status, 0)
             self.exit_cb_called += 1
@@ -117,17 +112,16 @@ class ProcessTest(unittest2.TestCase):
         def stdout_read_cb(handle, data, error):
             self.received_output = data.strip()
             handle.close(handle_close_cb)
-        loop = pyuv.Loop.default_loop()
-        stdout_pipe = pyuv.Pipe(loop)
+        stdout_pipe = pyuv.Pipe(self.loop)
         stdio = []
         stdio.append(pyuv.StdIO(flags=pyuv.UV_IGNORE))
         stdio.append(pyuv.StdIO(stream=stdout_pipe, flags=pyuv.UV_CREATE_PIPE|pyuv.UV_WRITABLE_PIPE))
-        proc = pyuv.Process(loop)
+        proc = pyuv.Process(self.loop)
         proc.spawn(file=sys.executable, args=["proc_env_stdout.py"],
                    env={"TEST": "TEST"}, exit_callback=proc_exit_cb,
                    stdio=stdio)
         stdout_pipe.start_read(stdout_read_cb)
-        loop.run()
+        self.loop.run()
         self.assertEqual(self.exit_cb_called, 1)
         self.assertEqual(self.close_cb_called, 2)
         self.assertEqual(self.received_output, b"TEST")
@@ -139,7 +133,7 @@ class ProcessTest(unittest2.TestCase):
         self.exit_status = -1
         self.term_signal = 0
         def handle_close_cb(handle):
-            self.close_cb_called +=1
+            self.close_cb_called += 1
         def proc_exit_cb(proc, exit_status, term_signal):
             self.exit_cb_called += 1
             self.exit_status = exit_status
@@ -151,18 +145,17 @@ class ProcessTest(unittest2.TestCase):
             handle.close(handle_close_cb)
         def stdin_write_cb(handle, error):
             handle.close(handle_close_cb)
-        loop = pyuv.Loop.default_loop()
-        stdin_pipe = pyuv.Pipe(loop)
-        stdout_pipe = pyuv.Pipe(loop)
+        stdin_pipe = pyuv.Pipe(self.loop)
+        stdout_pipe = pyuv.Pipe(self.loop)
         stdio = []
         stdio.append(pyuv.StdIO(stream=stdin_pipe, flags=pyuv.UV_CREATE_PIPE|pyuv.UV_READABLE_PIPE))
         stdio.append(pyuv.StdIO(stream=stdout_pipe, flags=pyuv.UV_CREATE_PIPE|pyuv.UV_WRITABLE_PIPE))
-        proc = pyuv.Process(loop)
+        proc = pyuv.Process(self.loop)
         proc.spawn(file=sys.executable, args=["proc_stdin_stdout.py"],
                    exit_callback=proc_exit_cb, stdio=stdio)
         stdout_pipe.start_read(stdout_read_cb)
-        stdin_pipe.write(b"TEST"+common.linesep, stdin_write_cb)
-        loop.run()
+        stdin_pipe.write(b"TEST"+linesep, stdin_write_cb)
+        self.loop.run()
         self.assertEqual(self.exit_cb_called, 1)
         self.assertEqual(self.close_cb_called, 3)
         self.assertEqual(self.received_output, b"TEST")
@@ -173,7 +166,7 @@ class ProcessTest(unittest2.TestCase):
         self.exit_status = -1
         self.term_signal = 0
         def handle_close_cb(proc):
-            self.close_cb_called +=1
+            self.close_cb_called += 1
         def proc_exit_cb(proc, exit_status, term_signal):
             self.exit_cb_called += 1
             self.exit_status = exit_status
@@ -182,13 +175,12 @@ class ProcessTest(unittest2.TestCase):
         def timer_cb(timer):
             timer.close(handle_close_cb)
             proc.kill(15)
-        loop = pyuv.Loop.default_loop()
-        timer = pyuv.Timer(loop)
+        timer = pyuv.Timer(self.loop)
         timer.start(timer_cb, 0.1, 0)
-        proc = pyuv.Process(loop)
+        proc = pyuv.Process(self.loop)
         proc.spawn(file=sys.executable, args=["proc_infinite.py"],
                    exit_callback=proc_exit_cb)
-        loop.run()
+        self.loop.run()
         self.assertEqual(self.exit_cb_called, 1)
         self.assertEqual(self.close_cb_called, 2)
         if sys.platform == 'win32':
@@ -202,7 +194,7 @@ class ProcessTest(unittest2.TestCase):
         self.exit_cb_called = 0
         self.close_cb_called = 0
         def proc_close_cb(proc):
-            self.close_cb_called +=1
+            self.close_cb_called += 1
         def proc_exit_cb(proc, exit_status, term_signal):
             self.assertEqual(exit_status, 0)
             self.exit_cb_called += 1
@@ -211,11 +203,10 @@ class ProcessTest(unittest2.TestCase):
             self.skipTest("test disabled if running as non-root")
             return
         p_info = pwd.getpwnam("nobody")
-        loop = pyuv.Loop.default_loop()
-        proc = pyuv.Process(loop)
+        proc = pyuv.Process(self.loop)
         proc.spawn(file="./proc_basic.py", exit_callback=proc_exit_cb, uid=p_info.pw_uid, gid=p_info.pw_gid, flags=pyuv.UV_PROCESS_SETUID|pyuv.UV_PROCESS_SETGID)
         pid = proc.pid
-        loop.run()
+        self.loop.run()
         self.assertEqual(self.exit_cb_called, 1)
         self.assertEqual(self.close_cb_called, 1)
         self.assertNotEqual(pid, None)
@@ -225,7 +216,7 @@ class ProcessTest(unittest2.TestCase):
         self.exit_cb_called = 0
         self.close_cb_called = 0
         def proc_close_cb(proc):
-            self.close_cb_called +=1
+            self.close_cb_called += 1
         def proc_exit_cb(proc, exit_status, term_signal):
             self.assertNotEqual(exit_status, 0)
             self.exit_cb_called += 1
@@ -233,10 +224,9 @@ class ProcessTest(unittest2.TestCase):
         if os.getuid() != 0:
             self.skipTest("test disabled if running as non-root")
             return
-        loop = pyuv.Loop.default_loop()
-        proc = pyuv.Process(loop)
+        proc = pyuv.Process(self.loop)
         proc.spawn(file="./proc_basic.py", exit_callback=proc_exit_cb, uid=-42424242, flags=pyuv.UV_PROCESS_SETUID)
-        loop.run()
+        self.loop.run()
         self.assertEqual(self.exit_cb_called, 1)
         self.assertEqual(self.close_cb_called, 1)
 
@@ -244,13 +234,12 @@ class ProcessTest(unittest2.TestCase):
         self.exit_cb_called = 0
         def proc_exit_cb(proc, exit_status, term_signal):
             self.exit_cb_called += 1
-        loop = pyuv.Loop.default_loop()
-        proc = pyuv.Process(loop)
+        proc = pyuv.Process(self.loop)
         proc.spawn(file=sys.executable, args=["proc_basic.py"],
                    exit_callback=proc_exit_cb, flags=pyuv.UV_PROCESS_DETACHED)
         proc.ref = False
         pid = proc.pid
-        loop.run()
+        self.loop.run()
         self.assertEqual(self.exit_cb_called, 0)
         proc.kill(0)
         proc.kill(15)

--- a/tests/test_signal.py
+++ b/tests/test_signal.py
@@ -4,12 +4,12 @@ import signal
 import time
 import threading
 
-from common import unittest2, platform_skip
+from common import unittest2, platform_skip, TestCase
 import pyuv
 
 
 @platform_skip(["win32"])
-class SignalTest(unittest2.TestCase):
+class SignalTest(TestCase):
 
     def signal_cb(self, handle, signum):
         self.assertEqual(signum, signal.SIGUSR1)
@@ -24,7 +24,6 @@ class SignalTest(unittest2.TestCase):
     def test_signal1(self):
         self.async_cb_called = 0
         self.signal_cb_called = 0
-        self.loop = pyuv.Loop.default_loop()
         self.async = pyuv.Async(self.loop, self.async_cb)
         self.signal_h = pyuv.Signal(self.loop)
         self.signal_h.start(self.signal_cb, signal.SIGUSR1)
@@ -67,4 +66,3 @@ class MultiLoopSignalTest(unittest2.TestCase):
 
 if __name__ == '__main__':
     unittest2.main(verbosity=2)
-

--- a/tests/test_tcp.py
+++ b/tests/test_tcp.py
@@ -3,8 +3,7 @@
 import socket
 import sys
 
-from common import unittest2
-import common
+from common import unittest2, linesep, TestCase
 import pyuv
 
 try:
@@ -16,58 +15,54 @@ except NameError:
 
 TEST_PORT = 1234
 
-class TCPErrorTest(unittest2.TestCase):
+class TCPErrorTest(TestCase):
 
     def on_client_connect_error(self, client, error):
         self.assertNotEqual(error, None)
         client.close()
 
     def test_client1(self):
-        loop = pyuv.Loop.default_loop()
-        client = pyuv.TCP(loop)
+        client = pyuv.TCP(self.loop)
         client.connect(("127.0.0.1", TEST_PORT), self.on_client_connect_error)
-        loop.run()
+        self.loop.run()
 
     def test_client2(self):
-        loop = pyuv.Loop.default_loop()
-        client = pyuv.TCP(loop)
+        client = pyuv.TCP(self.loop)
         self.assertFalse(client.readable)
         self.assertFalse(client.writable)
         client.close()
-        loop.run()
+        self.loop.run()
 
     def test_open(self):
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        loop = pyuv.Loop.default_loop()
-        client = pyuv.TCP(loop)
+        client = pyuv.TCP(self.loop)
         client.open(sock.fileno())
         client.connect(("127.0.0.1", TEST_PORT), self.on_client_connect_error)
-        loop.run()
+        self.loop.run()
         sock.close()
 
     def test_raise(self):
-        loop = pyuv.Loop.default_loop()
-        tcp = pyuv.TCP(loop)
+        tcp = pyuv.TCP(self.loop)
         self.assertRaises(pyuv.error.TCPError, tcp.write, b"PING")
         tcp.close()
-        loop.run()
+        self.loop.run()
 
 
-class TCPTest(unittest2.TestCase):
+class TCPTest(TestCase):
 
     def setUp(self):
-        self.loop = pyuv.Loop.default_loop()
+        super(TCPTest, self).setUp()
         self.server = None
         self.client = None
         self.client_connections = []
 
     def on_connection(self, server, error):
         self.assertEqual(error, None)
-        client = pyuv.TCP(pyuv.Loop.default_loop())
+        client = pyuv.TCP(self.loop)
         server.accept(client)
         self.client_connections.append(client)
         client.start_read(self.on_client_connection_read)
-        client.write(b"PING"+common.linesep)
+        client.write(b"PING"+linesep)
 
     def on_client_connection_read(self, client, data, error):
         if data is None:
@@ -84,7 +79,7 @@ class TCPTest(unittest2.TestCase):
 
     def on_client_read(self, client, data, error):
         self.assertNotEqual(data, None)
-        self.assertEqual(data, b"PING"+common.linesep)
+        self.assertEqual(data, b"PING"+linesep)
         client.close()
 
     def test_tcp1(self):
@@ -96,17 +91,17 @@ class TCPTest(unittest2.TestCase):
         self.loop.run()
 
 
-class TCPTest2(unittest2.TestCase):
+class TCPTest2(TestCase):
 
     def setUp(self):
-        self.loop = pyuv.Loop.default_loop()
+        super(TCPTest2, self).setUp()
         self.server = None
         self.client = None
         self.write_cb_count = 0
 
     def on_connection(self, server, error):
         self.assertEqual(error, None)
-        client = pyuv.TCP(pyuv.Loop.default_loop())
+        client = pyuv.TCP(self.loop)
         server.accept(client)
         for x in range(1024):
             client.write(b"PING"*1000, self.on_client_write)
@@ -131,16 +126,16 @@ class TCPTest2(unittest2.TestCase):
         self.assertEqual(self.write_cb_count, 1024)
 
 
-class TCPTest3(unittest2.TestCase):
+class TCPTest3(TestCase):
 
     def setUp(self):
-        self.loop = pyuv.Loop.default_loop()
+        super(TCPTest3, self).setUp()
         self.server = None
         self.client = None
 
     def on_connection(self, server, error):
         self.assertEqual(error, None)
-        connection = pyuv.TCP(pyuv.Loop.default_loop())
+        connection = pyuv.TCP(self.loop)
         server.accept(connection)
         while connection.write_queue_size == 0:
             connection.write(b"PING"*1000)
@@ -162,16 +157,16 @@ class TCPTest3(unittest2.TestCase):
         self.loop.run()
 
 
-class TCPTestUnicode(unittest2.TestCase):
+class TCPTestUnicode(TestCase):
 
     def setUp(self):
-        self.loop = pyuv.Loop.default_loop()
+        super(TCPTestUnicode, self).setUp()
         self.server = None
         self.client = None
 
     def on_connection(self, server, error):
         self.assertEqual(error, None)
-        client = pyuv.TCP(pyuv.Loop.default_loop())
+        client = pyuv.TCP(self.loop)
         server.accept(client)
         if sys.version_info >= (3, 0):
             data = 'PÏNG'
@@ -199,17 +194,17 @@ class TCPTestUnicode(unittest2.TestCase):
         self.loop.run()
 
 
-class TCPTestMemoryview(unittest2.TestCase):
+class TCPTestMemoryview(TestCase):
 
     def setUp(self):
-        self.loop = pyuv.Loop.default_loop()
+        super(TCPTestMemoryview, self).setUp()
         self.server = None
         self.client = None
         self.client_connections = []
 
     def on_connection(self, server, error):
         self.assertEqual(error, None)
-        client = pyuv.TCP(pyuv.Loop.default_loop())
+        client = pyuv.TCP(self.loop)
         server.accept(client)
         self.client_connections.append(client)
         client.start_read(self.on_client_connection_read)
@@ -241,21 +236,21 @@ class TCPTestMemoryview(unittest2.TestCase):
         self.loop.run()
 
 
-class TCPTestNull(unittest2.TestCase):
+class TCPTestNull(TestCase):
 
     def setUp(self):
-        self.loop = pyuv.Loop.default_loop()
+        super(TCPTestNull, self).setUp()
         self.server = None
         self.client = None
         self.client_connections = []
 
     def on_connection(self, server, error):
         self.assertEqual(error, None)
-        client = pyuv.TCP(pyuv.Loop.default_loop())
+        client = pyuv.TCP(self.loop)
         server.accept(client)
         self.client_connections.append(client)
         client.start_read(self.on_client_connection_read)
-        client.write(b"PIN\x00G"+common.linesep)
+        client.write(b"PIN\x00G"+linesep)
 
     def on_client_connection_read(self, client, data, error):
         if data is None:
@@ -270,7 +265,7 @@ class TCPTestNull(unittest2.TestCase):
 
     def on_client_read(self, client, data, error):
         self.assertNotEqual(data, None)
-        self.assertEqual(data, b"PIN\x00G"+common.linesep)
+        self.assertEqual(data, b"PIN\x00G"+linesep)
         client.close()
 
     def test_tcp_null(self):
@@ -282,16 +277,16 @@ class TCPTestNull(unittest2.TestCase):
         self.loop.run()
 
 
-class TCPTestList(unittest2.TestCase):
+class TCPTestList(TestCase):
 
     def setUp(self):
-        self.loop = pyuv.Loop.default_loop()
+        super(TCPTestList, self).setUp()
         self.server = None
         self.client = None
         self.client_connections = []
 
     def on_connection(self, server, error):
-        client = pyuv.TCP(pyuv.Loop.default_loop())
+        client = pyuv.TCP(self.loop)
         server.accept(client)
         self.client_connections.append(client)
         client.start_read(self.on_client_connection_read)
@@ -322,15 +317,15 @@ class TCPTestList(unittest2.TestCase):
         self.loop.run()
 
 
-class TCPTestListUnicode(unittest2.TestCase):
+class TCPTestListUnicode(TestCase):
 
     def setUp(self):
-        self.loop = pyuv.Loop.default_loop()
+        super(TCPTestListUnicode, self).setUp()
         self.server = None
         self.client = None
 
     def on_connection(self, server, error):
-        client = pyuv.TCP(pyuv.Loop.default_loop())
+        client = pyuv.TCP(self.loop)
         server.accept(client)
         if sys.version_info >= (3, 0):
             data = 'PÏNG'
@@ -358,16 +353,16 @@ class TCPTestListUnicode(unittest2.TestCase):
         self.loop.run()
 
 
-class TCPTestListNull(unittest2.TestCase):
+class TCPTestListNull(TestCase):
 
     def setUp(self):
-        self.loop = pyuv.Loop.default_loop()
+        super(TCPTestListNull, self).setUp()
         self.server = None
         self.client = None
         self.client_connections = []
 
     def on_connection(self, server, error):
-        client = pyuv.TCP(pyuv.Loop.default_loop())
+        client = pyuv.TCP(self.loop)
         server.accept(client)
         self.client_connections.append(client)
         client.start_read(self.on_client_connection_read)
@@ -398,16 +393,16 @@ class TCPTestListNull(unittest2.TestCase):
         self.loop.run()
 
 
-class TCPTestInvalidData(unittest2.TestCase):
+class TCPTestInvalidData(TestCase):
 
     def setUp(self):
-        self.loop = pyuv.Loop.default_loop()
+        super(TCPTestInvalidData, self).setUp()
         self.server = None
         self.client = None
         self.client_connections = []
 
     def on_connection(self, server, error):
-        client = pyuv.TCP(pyuv.Loop.default_loop())
+        client = pyuv.TCP(self.loop)
         server.accept(client)
         self.client_connections.append(client)
         client.start_read(self.on_client_connection_read)
@@ -445,27 +440,26 @@ class TCPTestInvalidData(unittest2.TestCase):
         self.loop.run()
 
 
-class TCPShutdownTest(unittest2.TestCase):
+class TCPShutdownTest(TestCase):
 
     def setUp(self):
-        self.loop = pyuv.Loop.default_loop()
+        super(TCPShutdownTest, self).setUp()
         self.server = None
         self.client = None
         self.client_connections = []
 
     def on_connection(self, server, error):
-        client = pyuv.TCP(pyuv.Loop.default_loop())
+        client = pyuv.TCP(self.loop)
         server.accept(client)
         self.client_connections.append(client)
         client.start_read(self.on_client_connection_read)
-        client.write(b"PING"+common.linesep)
+        client.write(b"PING"+linesep)
 
     def on_client_connection_read(self, client, data, error):
         if data is None:
             client.close(self.on_close)
             self.client_connections.remove(client)
             self.server.close(self.on_close)
-            return
 
     def on_client_connection(self, client, error):
         self.assertEqual(error, None)
@@ -480,7 +474,7 @@ class TCPShutdownTest(unittest2.TestCase):
 
     def on_client_read(self, client, data, error):
         self.assertNotEqual(data, None)
-        self.assertEqual(data, b"PING"+common.linesep)
+        self.assertEqual(data, b"PING"+linesep)
         client.shutdown(self.on_client_shutdown)
 
     def test_tcp_shutdown(self):
@@ -496,19 +490,16 @@ class TCPShutdownTest(unittest2.TestCase):
         self.assertEqual(self.close_cb_called, 3)
 
 
-class TCPFlagsTest(unittest2.TestCase):
+class TCPFlagsTest(TestCase):
 
     def test_tcp_flags(self):
-        loop = pyuv.Loop.default_loop()
-        tcp = pyuv.TCP(loop)
+        tcp = pyuv.TCP(self.loop)
         tcp.nodelay(True)
         tcp.keepalive(True, 60)
         tcp.simultaneous_accepts(True)
         tcp.close()
-        loop.run()
-        self.assertTrue(True)
+        self.loop.run()
 
 
 if __name__ == '__main__':
     unittest2.main(verbosity=2)
-

--- a/tests/test_threadpool.py
+++ b/tests/test_threadpool.py
@@ -4,7 +4,7 @@ import sys
 import threading
 import time
 
-from common import unittest2
+from common import unittest2, TestCase
 import pyuv
 
 
@@ -24,12 +24,12 @@ class WorkItem(object):
             self._cb = None
 
 
-class ThreadPoolTest(unittest2.TestCase):
+class ThreadPoolTest(TestCase):
 
     def setUp(self):
+        super(ThreadPoolTest, self).setUp()
         self.pool_cb_called = 0
         self.pool_after_work_cb_called = 0
-        self.loop = pyuv.Loop.default_loop()
 
     def run_in_pool(self, *args, **kw):
         self.pool_cb_called += 1

--- a/tests/test_timer.py
+++ b/tests/test_timer.py
@@ -1,9 +1,9 @@
 
-from common import unittest2
+from common import unittest2, TestCase
 import pyuv
 
 
-class TimerTest(unittest2.TestCase):
+class TimerTest(TestCase):
 
     def test_timer1(self):
         self.timer_cb_called = 0
@@ -11,10 +11,9 @@ class TimerTest(unittest2.TestCase):
             self.timer_cb_called += 1
             timer.stop()
             timer.close()
-        loop = pyuv.Loop.default_loop()
-        timer = pyuv.Timer(loop)
+        timer = pyuv.Timer(self.loop)
         timer.start(timer_cb, 0.1, 0)
-        loop.run()
+        self.loop.run()
         self.assertEqual(self.timer_cb_called, 1)
 
     def test_timer_never(self):
@@ -23,11 +22,10 @@ class TimerTest(unittest2.TestCase):
             self.timer_cb_called += 1
             timer.stop()
             timer.close()
-        loop = pyuv.Loop.default_loop()
-        timer = pyuv.Timer(loop)
+        timer = pyuv.Timer(self.loop)
         timer.start(timer_cb, 0.1, 0)
         timer.close()
-        loop.run()
+        self.loop.run()
         self.assertEqual(self.timer_cb_called, 0)
 
     def test_timer_ref1(self):
@@ -36,9 +34,8 @@ class TimerTest(unittest2.TestCase):
             self.timer_cb_called += 1
             timer.stop()
             timer.close()
-        loop = pyuv.Loop.default_loop()
-        self.timer = pyuv.Timer(loop)
-        loop.run()
+        self.timer = pyuv.Timer(self.loop)
+        self.loop.run()
         self.assertEqual(self.timer_cb_called, 0)
 
     def test_timer_ref2(self):
@@ -47,17 +44,15 @@ class TimerTest(unittest2.TestCase):
             self.timer_cb_called += 1
             timer.stop()
             timer.close()
-        loop = pyuv.Loop.default_loop()
-        self.timer = pyuv.Timer(loop)
+        self.timer = pyuv.Timer(self.loop)
         self.timer.start(timer_cb, 0.1, 0)
         self.timer.ref = False
-        loop.run()
+        self.loop.run()
         self.assertEqual(self.timer_cb_called, 0)
         self.timer.ref = True
-        loop.run()
+        self.loop.run()
         self.assertEqual(self.timer_cb_called, 1)
 
 
 if __name__ == '__main__':
     unittest2.main(verbosity=2)
-

--- a/tests/test_tty.py
+++ b/tests/test_tty.py
@@ -1,25 +1,23 @@
 
 import sys
 
-from common import unittest2, platform_skip
+from common import unittest2, platform_skip, TestCase
 import pyuv
 
 
 @platform_skip(["win32"])
-class TYTest(unittest2.TestCase):
+class TYTest(TestCase):
 
     def test_tty1(self):
-        loop = pyuv.Loop.default_loop()
-        tty = pyuv.TTY(loop, sys.stdin.fileno(), True)
+        tty = pyuv.TTY(self.loop, sys.stdin.fileno(), True)
         w, h = tty.get_winsize()
         self.assertNotEqual((w, h), (None, None))
 
         tty.close()
 
-        loop.run()
+        self.loop.run()
         tty.reset_mode()
 
 
 if __name__ == '__main__':
     unittest2.main(verbosity=2)
-

--- a/tests/test_udp.py
+++ b/tests/test_udp.py
@@ -1,6 +1,5 @@
 
-from common import unittest2, platform_skip
-import common
+from common import unittest2, linesep, platform_skip, TestCase
 import pyuv
 import socket
 import sys
@@ -10,10 +9,10 @@ TEST_PORT = 12345
 TEST_PORT2 = 12346
 MULTICAST_ADDRESS = "239.255.0.1"
 
-class UDPTest(unittest2.TestCase):
+class UDPTest(TestCase):
 
     def setUp(self):
-        self.loop = pyuv.Loop.default_loop()
+        super(UDPTest, self).setUp()
         self.server = None
         self.client = None
 
@@ -25,7 +24,7 @@ class UDPTest(unittest2.TestCase):
         ip, port = ip_port
         data = data.strip()
         self.assertEqual(data, b"PING")
-        self.server.send((ip, port), b"PONG"+common.linesep)
+        self.server.send((ip, port), b"PONG"+linesep)
 
     def on_client_recv(self, handle, ip_port, flags, data, error):
         self.assertEqual(flags, 0)
@@ -36,7 +35,7 @@ class UDPTest(unittest2.TestCase):
         self.server.close(self.on_close)
 
     def timer_cb(self, timer):
-        self.client.send(("127.0.0.1", TEST_PORT), b"PING"+common.linesep)
+        self.client.send(("127.0.0.1", TEST_PORT), b"PING"+linesep)
         timer.close(self.on_close)
 
     def test_udp_pingpong(self):
@@ -59,10 +58,10 @@ class UDPTest(unittest2.TestCase):
         self.assertEqual(self.on_close_called, 3)
 
 
-class UDPTestNull(unittest2.TestCase):
+class UDPTestNull(TestCase):
 
     def setUp(self):
-        self.loop = pyuv.Loop.default_loop()
+        super(UDPTestNull, self).setUp()
         self.server = None
         self.client = None
 
@@ -74,7 +73,7 @@ class UDPTestNull(unittest2.TestCase):
         ip, port = ip_port
         data = data.strip()
         self.assertEqual(data, b"PIN\x00G")
-        self.server.send((ip, port), b"PONG"+common.linesep)
+        self.server.send((ip, port), b"PONG"+linesep)
 
     def on_client_recv(self, handle, ip_port, flags, data, error):
         self.assertEqual(flags, 0)
@@ -85,7 +84,7 @@ class UDPTestNull(unittest2.TestCase):
         self.server.close(self.on_close)
 
     def timer_cb(self, timer):
-        self.client.send(("127.0.0.1", TEST_PORT), b"PIN\x00G"+common.linesep)
+        self.client.send(("127.0.0.1", TEST_PORT), b"PIN\x00G"+linesep)
         timer.close(self.on_close)
 
     def test_udp_pingpong_null(self):
@@ -102,10 +101,10 @@ class UDPTestNull(unittest2.TestCase):
         self.assertEqual(self.on_close_called, 3)
 
 
-class UDPTestList(unittest2.TestCase):
+class UDPTestList(TestCase):
 
     def setUp(self):
-        self.loop = pyuv.Loop.default_loop()
+        super(UDPTestList, self).setUp()
         self.server = None
         self.client = None
 
@@ -117,7 +116,7 @@ class UDPTestList(unittest2.TestCase):
         ip, port = ip_port
         data = data.strip()
         self.assertEqual(data, b"PING")
-        self.server.sendlines((ip, port), [b"PONG", common.linesep])
+        self.server.sendlines((ip, port), [b"PONG", linesep])
 
     def on_client_recv(self, handle, ip_port, flags, data, error):
         self.assertEqual(flags, 0)
@@ -128,7 +127,7 @@ class UDPTestList(unittest2.TestCase):
         self.server.close(self.on_close)
 
     def timer_cb(self, timer):
-        self.client.sendlines(("127.0.0.1", TEST_PORT), [b"PING", common.linesep])
+        self.client.sendlines(("127.0.0.1", TEST_PORT), [b"PING", linesep])
         timer.close(self.on_close)
 
     def test_udp_pingpong_list(self):
@@ -145,10 +144,10 @@ class UDPTestList(unittest2.TestCase):
         self.assertEqual(self.on_close_called, 3)
 
 
-class UDPTestListNull(unittest2.TestCase):
+class UDPTestListNull(TestCase):
 
     def setUp(self):
-        self.loop = pyuv.Loop.default_loop()
+        super(UDPTestListNull, self).setUp()
         self.server = None
         self.client = None
 
@@ -160,7 +159,7 @@ class UDPTestListNull(unittest2.TestCase):
         ip, port = ip_port
         data = data.strip()
         self.assertEqual(data, b"PIN\x00G")
-        self.server.sendlines((ip, port), [b"PONG", common.linesep])
+        self.server.sendlines((ip, port), [b"PONG", linesep])
 
     def on_client_recv(self, handle, ip_port, flags, data, error):
         self.assertEqual(flags, 0)
@@ -171,7 +170,7 @@ class UDPTestListNull(unittest2.TestCase):
         self.server.close(self.on_close)
 
     def timer_cb(self, timer):
-        self.client.sendlines(("127.0.0.1", TEST_PORT), [b"PIN\x00G", common.linesep])
+        self.client.sendlines(("127.0.0.1", TEST_PORT), [b"PIN\x00G", linesep])
         timer.close(self.on_close)
 
     def test_udp_pingpong_list_null(self):
@@ -188,10 +187,10 @@ class UDPTestListNull(unittest2.TestCase):
         self.assertEqual(self.on_close_called, 3)
 
 
-class UDPTestInvalidData(unittest2.TestCase):
+class UDPTestInvalidData(TestCase):
 
     def setUp(self):
-        self.loop = pyuv.Loop.default_loop()
+        super(UDPTestInvalidData, self).setUp()
         self.server = None
         self.client = None
 
@@ -238,10 +237,10 @@ else:
         yield MULTICAST_ADDRESS
 
 
-class UDPTestMulticast(unittest2.TestCase):
+class UDPTestMulticast(TestCase):
 
     def setUp(self):
-        self.loop = pyuv.Loop.default_loop()
+        super(UDPTestMulticast, self).setUp()
         self.server = None
         self.clients = None
         self.received_data = None
@@ -294,10 +293,7 @@ class UDPTestMulticast(unittest2.TestCase):
         self.assertEqual(self.received_data, b"PING")
 
 
-class UDPTestBigDatagram(unittest2.TestCase):
-
-    def setUp(self):
-        self.loop = pyuv.Loop.default_loop()
+class UDPTestBigDatagram(TestCase):
 
     def send_cb(self, handle, error):
         self.handle.close()
@@ -312,21 +308,19 @@ class UDPTestBigDatagram(unittest2.TestCase):
         self.assertEqual(self.errorno, pyuv.errno.UV_EMSGSIZE)
 
 
-class UDPTestOpen(unittest2.TestCase):
+class UDPTestOpen(TestCase):
 
     def test_udp_open(self):
         sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-        loop = pyuv.Loop.default_loop()
-        handle = pyuv.UDP(loop)
+        handle = pyuv.UDP(self.loop)
         handle.open(sock.fileno())
         try:
             handle.bind(("1.2.3.4", TEST_PORT))
         except pyuv.error.UDPError as e:
             self.assertEqual(e.args[0], pyuv.errno.UV_EADDRNOTAVAIL)
-        loop.run()
+        self.loop.run()
         sock.close()
 
 
 if __name__ == '__main__':
     unittest2.main(verbosity=2)
-

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,11 +1,11 @@
 
-from common import unittest2
+from common import unittest2, TestCase
 
 import pyuv
 import socket
 
 
-class UtilTest(unittest2.TestCase):
+class UtilTest(TestCase):
 
     def test_hrtime(self):
         r = pyuv.util.hrtime()
@@ -42,11 +42,9 @@ class UtilTest(unittest2.TestCase):
     def test_getaddrinfo(self):
         def getaddrinfo_cb(result, errorno):
             self.assertEqual(errorno, None)
-        loop = pyuv.Loop.default_loop()
-        pyuv.util.getaddrinfo(loop, getaddrinfo_cb, 'localhost', 80, socket.AF_INET)
-        loop.run()
+        pyuv.util.getaddrinfo(self.loop, getaddrinfo_cb, 'localhost', 80, socket.AF_INET)
+        self.loop.run()
 
 
 if __name__ == '__main__':
     unittest2.main(verbosity=2)
-

--- a/tests/test_walk.py
+++ b/tests/test_walk.py
@@ -2,30 +2,29 @@
 import gc
 import weakref
 
-from common import unittest2
+from common import unittest2, TestCase
 import pyuv
 
 
-class WalkTest(unittest2.TestCase):
+class WalkTest(TestCase):
 
     def test_walk(self):
         def timer_cb(timer):
             handles = []
             def walk_cb(handle):
                 handles.append(handle)
-            loop.walk(walk_cb)
+            self.loop.walk(walk_cb)
             self.assertTrue(timer in handles)
             timer.close()
-        loop = pyuv.Loop.default_loop()
-        timer = pyuv.Timer(loop)
+        timer = pyuv.Timer(self.loop)
         w_timer = weakref.ref(timer)
         self.assertNotEqual(w_timer(), None)
         timer.start(timer_cb, 0.1, 0.0)
-        loop.run()
+        self.loop.run()
         handles = []
         def walk_cb(handle):
             handles.append(handle)
-        loop.walk(walk_cb)
+        self.loop.walk(walk_cb)
         self.assertTrue(timer not in handles)
         handles = None
         timer = None
@@ -33,7 +32,5 @@ class WalkTest(unittest2.TestCase):
         self.assertEqual(w_timer(), None)
 
 
-
 if __name__ == '__main__':
     unittest2.main(verbosity=2)
-

--- a/tests/test_weakref.py
+++ b/tests/test_weakref.py
@@ -1,28 +1,26 @@
 
 import weakref
 
-from common import unittest2
+from common import unittest2, TestCase
 import pyuv
 
 
-class WeakrefTest(unittest2.TestCase):
+class WeakrefTest(TestCase):
     handle_types = ('Check', 'Idle', 'Pipe', 'Prepare', 'TCP', 'Timer', 'UDP')
 
     def test_weakref(self):
-        loop = pyuv.Loop()
         refs = []
         for type in self.handle_types:
             klass = getattr(pyuv, type)
-            obj = klass(loop)
+            obj = klass(self.loop)
             refs.append(weakref.ref(obj))
             del obj
         for ref in refs:
             self.assertNotEqual(ref(), None)
-        loop.run()
+        self.loop.run()
         for ref in refs:
             self.assertEqual(ref(), None)
 
 
 if __name__ == '__main__':
     unittest2.main(verbosity=2)
-


### PR DESCRIPTION
Exceptions in callbacks are caught with Loop.excepthook, are stored as
an attribute of the Loop instance, and the loop is stopped. When
exiting Loop.run() or Loop.walk(), if any exceptions were caught, they
are re-raised.

The creation of the loop is extracted from the individual test classes
into TestCase. A separate loop instance is used for every test instead
of the default loop, to improve isolation between tests.
