### PR TITLE
Implement excepthook as a method rather than an attribute.

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -1,4 +1,5 @@
 
+import io
 import os
 import sys
 sys.path.insert(0, '../')
@@ -14,6 +15,7 @@ else:
 
 if sys.version_info >= (3,):
     linesep = os.linesep.encode()
+    StdBufferIO = io.StringIO
 
     def reraise(typ, value, tb):
         if value.__traceback__ is not tb:
@@ -22,6 +24,7 @@ if sys.version_info >= (3,):
 
 else:
     linesep = os.linesep
+    StdBufferIO = io.BytesIO
 
     exec("""\
 def reraise(typ, value, tb):

--- a/tests/test_excepthook.py
+++ b/tests/test_excepthook.py
@@ -1,0 +1,154 @@
+"""Tests for Loop.excepthook"""
+
+from common import unittest2, StdBufferIO
+
+import pyuv
+import re
+import sys
+
+
+class ExcepthookTestCase(unittest2.TestCase):
+    """Base class for excepthook tests"""
+
+    def assertOutput(self, regexp):
+        output = sys.stderr.getvalue()
+        match = re.match(regexp, output)
+        if match is None:
+            self.fail("Output doesn't match %s\n\nOutput:\n-------\n%s"
+                      % (unittest2.util.safe_repr(regexp), output))
+
+    def setUp(self):
+        super(ExcepthookTestCase, self).setUp()
+        self.stderr = sys.stderr
+        sys.stderr = StdBufferIO()
+        self.loop = self.make_loop()
+        self.loop.calls = []
+        self.loop.exception = None
+
+    def tearDown(self):
+        sys.stderr = self.stderr
+        super(ExcepthookTestCase, self).tearDown()
+
+    def excepthook_cb(self, typ, value, tb):
+        self.loop.calls.append((typ, value, tb))
+        if self.loop.exception:
+            raise self.loop.exception
+
+    def setup_idle(self, exception=None):
+        def idle_cb(handle):
+            handle.stop()
+            handle.close()
+            if exception is not None:
+                raise exception
+        self.idle = pyuv.Idle(self.loop)
+        self.idle.start(idle_cb)
+
+
+class TestExcepthookDefault(ExcepthookTestCase):
+    """Test the default excepthook method"""
+
+    def make_loop(self):
+        return pyuv.Loop()
+
+    def test_default_method(self):
+        self.setup_idle(RuntimeError("Bad"))
+        self.loop.run()
+        self.assertOutput("(?s)^Unhandled exception in callback\n"
+                          "Traceback.*\nRuntimeError: Bad\n$")
+        self.assertNotIn('AttributeError', sys.stderr.getvalue())
+
+
+class LoopNoExcepthook(pyuv.Loop):
+
+    @property
+    def excepthook(self):
+        raise AttributeError("object has no attribute 'excepthook'")
+
+
+class TestExcepthookMissing(TestExcepthookDefault):
+    """Test a missing excepthook attribute"""
+
+    def make_loop(self):
+        return LoopNoExcepthook()
+
+
+class TestExcepthookNone(TestExcepthookDefault):
+    """Test setting excepthook to None"""
+
+    def make_loop(self):
+        loop = pyuv.Loop()
+        loop.excepthook = None
+        return loop
+
+
+class LoopBadAttr(pyuv.Loop):
+
+    @property
+    def excepthook(self):
+        raise TypeError("oops")
+
+
+class TestExcepthookBadAttr(ExcepthookTestCase):
+    """Test exception while retrieving the excepthook attribute"""
+
+    def make_loop(self):
+        return LoopBadAttr()
+
+    def test_default_method(self):
+        self.setup_idle(RuntimeError("Bad"))
+        self.loop.run()
+        self.assertOutput("(?s)^Exception while getting excepthook\n"
+                          "Traceback.*\nTypeError: oops\n\n"
+                          "Unhandled exception in callback\n"
+                          "Traceback.*\nRuntimeError: Bad\n$")
+
+
+class TestExcepthookAttribute(ExcepthookTestCase):
+    """Test setting Loop.excepthook as an instance attribute"""
+
+    def make_loop(self):
+        loop = pyuv.Loop()
+        loop.excepthook = self.excepthook_cb
+        return loop
+
+    def test_no_exception(self):
+        self.setup_idle()
+        self.loop.run()
+        self.assertEqual(0, len(self.loop.calls))
+
+    def test_exception(self):
+        exception = RuntimeError("Bad")
+        self.setup_idle(exception)
+        self.loop.run()
+        self.assertEqual(1, len(self.loop.calls))
+        self.assertEqual((exception.__class__, exception),
+                         self.loop.calls[0][:2])
+
+    def test_exception_in_hook(self):
+        exception = RuntimeError("Bad")
+        self.setup_idle(exception)
+        self.loop.exception = NameError("abc")
+        self.loop.run()
+        self.assertOutput("(?s)^Unhandled exception in excepthook\n"
+                          "Traceback.*\nNameError: abc\n\n"
+                          "Unhandled exception in callback\n"
+                          "Traceback.*\nRuntimeError: Bad\n$")
+
+
+class LoopOverride(pyuv.Loop):
+
+    def excepthook(self, typ, value, tb):
+        self.calls.append((typ, value, tb))
+        if self.exception:
+            raise self.exception
+
+
+class TestExcepthookOverride(TestExcepthookAttribute):
+    """Test subclassing Loop and overriding excepthook"""
+
+    def make_loop(self):
+        return LoopOverride()
+
+
+if __name__ == '__main__':
+    unittest2.main(verbosity=2)


### PR DESCRIPTION
This allows overriding excepthook in a subclass of Loop, in addition to
the current method of assigning to the excepthook instance attribute.

Added tests for the behavior of excepthook in the various cases.
