### PR TITLE
Return self instead of None from handle methods.

### DIFF
--- a/src/idle.c
+++ b/src/idle.c
@@ -56,7 +56,8 @@ Idle_func_start(Idle *self, PyObject *args)
     self->callback = callback;
     Py_XDECREF(tmp);
 
-    Py_RETURN_NONE;
+    Py_INCREF(self);
+    return (PyObject *)self;
 }
 
 
@@ -77,7 +78,8 @@ Idle_func_stop(Idle *self)
     Py_XDECREF(self->callback);
     self->callback = NULL;
 
-    Py_RETURN_NONE;
+    Py_INCREF(self);
+    return (PyObject *)self;
 }
 
 

--- a/tests/test_idle.py
+++ b/tests/test_idle.py
@@ -12,8 +12,7 @@ class IdleTest(unittest2.TestCase):
             idle.stop()
             idle.close()
         loop = pyuv.Loop.default_loop()
-        idle = pyuv.Idle(loop)
-        idle.start(idle_cb)
+        idle = pyuv.Idle(loop).start(idle_cb)
         loop.run()
         self.assertEqual(self.idle_cb_called, 1)
 


### PR DESCRIPTION
This is just an example for the Idle handle, the same could be applied to all the other handles. I find it very convenient to be able to chain calls to configure a handle and still be able to store a reference to the handle, all on one line.

Please let me know if you think this is a worthy addition, and I'll do the other handles as well, and update the documentation.
