### PR TITLE
Fix echo-pipe.py

### DIFF
--- a/examples/echo-pipe.py
+++ b/examples/echo-pipe.py
@@ -1,4 +1,3 @@
-
 import signal
 import sys
 import pyuv
@@ -12,8 +11,10 @@ def on_pipe_read(handle, data, error):
         pipe_stdout.write(data)
 
 def signal_cb(handle, signum):
-    pipe_stdin.close()
-    pipe_stdout.close()
+    if not pipe_stdin.closed:
+        pipe_stdin.close()
+    if not pipe_stdin.closed:
+        pipe_stdout.close()
     signal_h.close()
 
 


### PR DESCRIPTION
```
$python echo-pipe.py
C-d C-c
Traceback (most recent call last):
  File "echo-pipe.py", line 14, in signal_cb
    pipe_stdin.close()
pyuv.error.HandleClosedError: Handle is closing/closed
```
