### PR TITLE
Fix Windows build: handles is declared after statement

### DIFF
--- a/src/loop.c
+++ b/src/loop.c
@@ -325,8 +325,8 @@ handles_walk_cb(uv_handle_t* handle, void* arg)
 static PyObject *
 Loop_handles_get(Loop *self, void *closure)
 {
-    UNUSED_ARG(closure);
     PyObject *handles;
+    UNUSED_ARG(closure);
 
     handles = PyList_New(0);
 


### PR DESCRIPTION
Hi,

Since the `handles` variable is declared after a statement, the VS C compiler complaints and the build fails:

```
C:\Program Files (x86)\Microsoft Visual Studio 9.0\VC\BIN\cl.exe /c /nologo /Ox
/MD /W3 /GS- /DNDEBUG -DMODULE_VERSION=0.11.1 -DLIBUV_REVISION=9d44d78 -DWIN32=1
 -IC:\Python\include -IC:\Python\PC -Ideps\libuv\include /Tcsrc/pyuv
.c /Fobuild\temp.win32-2.7\Release\src/pyuv.obj
pyuv.c
c:\users\user\python-packages\pyuv\src\loop.c(329) : error C2275
: 'PyObject' : illegal use of this type as an expression
        c:\python\include\object.h(108) : see declaration of 'PyObject'
```
