### PR TITLE
Fixed installation on Windows Python 3.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-# coding=utf8
+# coding=utf-8
 
 try:
     from setuptools import setup, Extension


### PR DESCRIPTION
Error with Python 3:

```
λ py -3 setup.py
  File "setup.py", line 1
SyntaxError: encoding problem: utf8
```
