### PR TITLE
undefined symbol "kvm_open" on FreeBSD 10

### DIFF
--- a/setup_libuv.py
+++ b/setup_libuv.py
@@ -133,6 +133,8 @@ class libuv_build_ext(build_ext):
             self.compiler.add_library('iphlpapi')
             self.compiler.add_library('psapi')
             self.compiler.add_library('ws2_32')
+        elif sys.platform.startswith('freebsd'):
+            self.compiler.add_library('kvm')
         build_ext.build_extensions(self)
 
     def get_libuv(self):


### PR DESCRIPTION
OS: FreeBSD 10.0-STABLE
python 2.7.6
pyuv 0.11.3

how to reproduce:
git clone ...
python setup.py build or bash build_inplace
python setup.py install

```
/projects/ % python test.py  
Traceback (most recent call last):
  File "test.py", line 4, in <module>
    import pyuv
  File "build/bdist.freebsd-10.0-STABLE-amd64/egg/pyuv.py", line 7, in <module>
  File "build/bdist.freebsd-10.0-STABLE-amd64/egg/pyuv.py", line 6, in __bootstrap__
ImportError: /home/ebfe/.python-eggs/pyuv-0.11.3-py2.7-freebsd-10.0-STABLE-amd64.egg-tmp/pyuv.so: Undefined symbol "kvm_open"
```
