### PR TITLE
Enable Python 3.4 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: python
 python:
   - "2.6"
   - "2.7"
-  - "3.2"
   - "3.3"
+  - "3.4"
 install:
   - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install --use-mirrors unittest2; fi
   - python setup.py install


### PR DESCRIPTION
Also, disabled Python 3.2, nobody cares about it anymore.
