### PR TITLE
Implement _fileno() for Stream and UDP

### DIFF
--- a/src/stream.c
+++ b/src/stream.c
@@ -407,6 +407,20 @@ Stream_func_writelines(Stream *self, PyObject *args)
 
 
 static PyObject *
+Stream_func__fileno(Stream *self)
+{
+    RAISE_IF_HANDLE_NOT_INITIALIZED(self, NULL);
+    RAISE_IF_HANDLE_CLOSED(self, PyExc_HandleClosedError, NULL);
+
+#ifdef PYUV_WINDOWS
+    return PyInt_FromLong(-1);
+#else
+    return PyInt_FromLong(((uv_stream_t *)UV_HANDLE(self))->io_watcher.fd);
+#endif
+}
+
+
+static PyObject *
 Stream_readable_get(Stream *self, void *closure)
 {
     UNUSED_ARG(closure);
@@ -474,6 +488,7 @@ Stream_tp_methods[] = {
     { "writelines", (PyCFunction)Stream_func_writelines, METH_VARARGS, "Write a sequence of data on the stream." },
     { "start_read", (PyCFunction)Stream_func_start_read, METH_VARARGS, "Start read data from the connected endpoint." },
     { "stop_read", (PyCFunction)Stream_func_stop_read, METH_NOARGS, "Stop read data from the connected endpoint." },
+    { "_fileno", (PyCFunction)Stream_func__fileno, METH_NOARGS, "Returns the libuv file descriptor. Private API, Unix only." },
     { NULL }
 };
 

--- a/src/udp.c
+++ b/src/udp.c
@@ -530,6 +530,20 @@ UDP_func_open(UDP *self, PyObject *args)
 }
 
 
+static PyObject *
+UDP_func__fileno(UDP *self)
+{
+    RAISE_IF_HANDLE_NOT_INITIALIZED(self, NULL);
+    RAISE_IF_HANDLE_CLOSED(self, PyExc_HandleClosedError, NULL);
+
+#ifdef PYUV_WINDOWS
+    return PyInt_FromLong(-1);
+#else
+    return PyInt_FromLong(self->udp_h.io_watcher.fd);
+#endif
+}
+
+
 static int
 UDP_tp_init(UDP *self, PyObject *args, PyObject *kwargs)
 {
@@ -604,6 +618,7 @@ UDP_tp_methods[] = {
     { "set_multicast_loop", (PyCFunction)UDP_func_set_multicast_loop, METH_VARARGS, "Set IP multicast loop flag. Makes multicast packets loop back to local sockets." },
     { "set_broadcast", (PyCFunction)UDP_func_set_broadcast, METH_VARARGS, "Set broadcast on or off." },
     { "set_ttl", (PyCFunction)UDP_func_set_ttl, METH_VARARGS, "Set the Time To Live." },
+    { "_fileno", (PyCFunction)UDP_func__fileno, METH_NOARGS, "Returns the libuv file descriptor. Private API, Unix only." },
     { NULL }
 };
 

--- a/tests/test_tcp.py
+++ b/tests/test_tcp.py
@@ -558,5 +558,41 @@ class TCPTryTest(TestCase):
         self.loop.run()
 
 
+class TCPTestFileno(TestCase):
+
+    def check_fileno(self, handle):
+        self.assertTrue(hasattr(handle, '_fileno'))
+        fd = handle._fileno()
+        self.assertIsInstance(fd, int)
+        if sys.platform.startswith('win'):
+            self.assertEqual(fd, -1)
+        else:
+            self.assertGreater(fd, -1)
+
+    def on_connection(self, server, error):
+        self.assertEqual(error, None)
+        self.check_fileno(server)
+        client = pyuv.TCP(self.loop)
+        server.accept(client)
+        self.check_fileno(client)
+        client.close()
+        server.close()
+
+    def on_client_connection(self, client, error):
+        self.assertEqual(error, None)
+        self.check_fileno(client)
+        client.close()
+
+    def test_fileno(self):
+        server = pyuv.TCP(self.loop)
+        server.bind(("0.0.0.0", TEST_PORT))
+        self.check_fileno(server)
+        server.listen(self.on_connection)
+        client = pyuv.TCP(self.loop)
+        client.connect(("127.0.0.1", TEST_PORT), self.on_client_connection)
+        self.check_fileno(client)
+        self.loop.run()
+
+
 if __name__ == '__main__':
     unittest2.main(verbosity=2)

--- a/tests/test_udp.py
+++ b/tests/test_udp.py
@@ -328,5 +328,23 @@ class UDPTestOpen(TestCase):
         self.loop.run()
 
 
+class UDPTestFileno(TestCase):
+
+    def check_fileno(self, handle):
+        self.assertTrue(hasattr(handle, '_fileno'))
+        fd = handle._fileno()
+        self.assertIsInstance(fd, int)
+        if sys.platform.startswith('win'):
+            self.assertEqual(fd, -1)
+        else:
+            self.assertGreater(fd, -1)
+
+    def test_udp_fileno(self):
+        server = pyuv.UDP(self.loop)
+        server.bind(("0.0.0.0", TEST_PORT))
+        self.check_fileno(server)
+        server.close()
+
+
 if __name__ == '__main__':
     unittest2.main(verbosity=2)


### PR DESCRIPTION
This method returns the libuv file descriptor for a Stream or a UDP handle.  It should be considered an internal API and can break things horribly if abused. The file descriptor that is returned will still be
"owned" by the libuv Handle, and libuv assumes it has full and unique ownership of the descriptor and that nobody will change it.

This method is Unix only. On Windows this returns -1.

The method is useful e.g. call non-invasive getsockopt() calls such as SO_PEERCRED on Pipes.

See also https://github.com/saghul/pyuv/issues/157 for an idea how a cleaner API might be added to libuv in the future.
