### PR TITLE
Fix refcounting bug in StdIO

### DIFF
--- a/src/process.c
+++ b/src/process.c
@@ -60,6 +60,7 @@ StdIO_stream_get(StdIO *self, void *closure)
     if (!self->stream) {
         Py_RETURN_NONE;
     } else {
+        Py_INCREF(self->stream);
         return self->stream;
     }
 }


### PR DESCRIPTION
Fix 2 nasty refcounting bugs in StdIO.

I don't understand the supposed logic behind the use of the "tmp" variable. Maybe this is some kind of cut and paste error? The stream is set once in the constructor and cannot be updated. So self->stream would always be NULL before setting it in tp_init.

The tp_getset bug is a simple forgotten INCREF. Just to be sure I checked all use of tp_getsets in pyuv and apart from this one they are all fine.
