### PR TITLE
Fix refcounting bug in func_excepthook().

### DIFF
--- a/src/loop.c
+++ b/src/loop.c
@@ -239,7 +239,7 @@ Loop_func_excepthook(Loop *self, PyObject *args)
     }
     Py_INCREF(exc);
     Py_INCREF(value);
-    Py_INCREF(args);
+    Py_INCREF(tb);
     PyErr_Restore(exc, value, tb);
     PySys_WriteStderr("Unhandled exception in callback\n");
     PyErr_PrintEx(0);


### PR DESCRIPTION
Found with python compiled with --with-pydebug.
