### PR TITLE
Add a missing close() for socket.

### DIFF
--- a/tests/test_poll.py
+++ b/tests/test_poll.py
@@ -84,6 +84,7 @@ class PollTest(TestCase):
         self.loop.run()
         self.assertTrue(self.poll.closed)
         self.assertEqual(self.poll.fileno(), -1)
+        self.sock.close()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This suppresses a ResourceWarning in Python 3.5alpha.
