### PR TITLE
setup_libuv.py-> libuv_revision from 06f9e14 to 49cb40c.

### DIFF
--- a/setup_libuv.py
+++ b/setup_libuv.py
@@ -94,7 +94,7 @@ class libuv_build_ext(build_ext):
     libuv_dir      = os.path.join('deps', 'libuv')
     libuv_repo     = 'https://github.com/joyent/libuv.git'
     libuv_branch   = 'master'
-    libuv_revision = '06f9e14'
+    libuv_revision = '49cb40c'
     libuv_patches  = []
 
     user_options = build_ext.user_options


### PR DESCRIPTION
fix an issue when installing pyuv in windows the visual studio will complain about "reserved": "struct" field redefination.
Change the libuv_revision from 06f9e14 to 49cb40c.
