### PR TITLE
allow to build in Windows SDK

### DIFF
--- a/setup_libuv.py
+++ b/setup_libuv.py
@@ -52,6 +52,9 @@ def prepare_windows_env(env):
     env.pop('VS110COMNTOOLS', None)
     if sys.version_info < (3, 3):
         env.pop('VS100COMNTOOLS', None)
+        env['GYP_MSVS_VERSION'] = '2008'
+    else:
+        env['GYP_MSVS_VERSION'] = '2010'
 
     if env.get('PYTHON'):
         return  # Already manually set by user.


### PR DESCRIPTION
If `GYP_MSVS_VERSION` is not set, gyp creates a project for VS 2010 / Windows SDK 7.1 (for now). So setup didn't work with Windows SDK 7.0 (which targets Python 2.7 / VS 2008).
