### PR TITLE
Do not iterate over non-pyuv handles.

### DIFF
--- a/src/handle.c
+++ b/src/handle.c
@@ -196,6 +196,7 @@ Handle_tp_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
     if (!self) {
         return NULL;
     }
+    self->__handle_magic = PYUV_HANDLE_MAGIC;
     self->initialized = False;
     self->uv_handle = NULL;
     self->weakreflist = NULL;

--- a/src/pyuv.h
+++ b/src/pyuv.h
@@ -166,6 +166,11 @@ typedef int Bool;
     } while(0)                                         \
 
 
+/* Non-pyuv handles are unlikely to contain that exact data, so this is at least
+   somewhat better than a guaranteed SIGSEGV when accessing`loop.handles`. */
+#define IS_PYUV_HANDLE(ptr) (ptr && ((Handle*)ptr)->__handle_magic == PYUV_HANDLE_MAGIC)
+#define PYUV_HANDLE_MAGIC &HandleType
+
 /* Python types definitions */
 
 /* Loop */
@@ -187,6 +192,7 @@ static PyTypeObject LoopType;
 /* Handle */
 typedef struct {
     PyObject_HEAD
+    void *__handle_magic;
     uv_handle_t *uv_handle;
     int flags;
     Bool initialized;


### PR DESCRIPTION
Found this bug by trying to `close` an aiouv loop after running a libh2o server: the aiouv loop attempts to access the `handles` attribute of a pyuv loop, but triggers an assertion because some of the handles were created by libh2o and therefore do not have `data` pointing to a `PyObject`.

Creating new `Handle` objects for such handles would probably be a better solution, but these automatically close the underlying uv handle when gc'd, and that's clearly undesirable. Simply ignoring handles that have no associated `Handle` objects was the best I could come up with. (Hey, at least it doesn't segfault anymore. Unless you're lucky enough to have some `data` that's not a `PyObject` but looks like it is one of type `HandleType`.)