### PR TITLE
Support building with MinGW-w64

### DIFF
--- a/setup_libuv.py
+++ b/setup_libuv.py
@@ -146,7 +146,8 @@ class libuv_build_ext(build_ext):
 
     def build_extensions(self):
         self.force = self.force or self.libuv_force_fetch or self.libuv_clean_compile
-        if self.use_system_libuv:
+
+        if self.compiler.compiler_type == 'mingw32' or self.use_system_libuv:
             self.compiler.add_library('uv')
         else:
             if sys.platform == 'win32':

--- a/setup_libuv.py
+++ b/setup_libuv.py
@@ -147,8 +147,6 @@ class libuv_build_ext(build_ext):
     def build_extensions(self):
         self.force = self.force or self.libuv_force_fetch or self.libuv_clean_compile
         if self.use_system_libuv:
-            if sys.platform == 'win32':
-                raise DistutilsError('using a system provided libuv is unsupported on Windows')
             self.compiler.add_library('uv')
         else:
             if sys.platform == 'win32':
@@ -163,7 +161,8 @@ class libuv_build_ext(build_ext):
             self.compiler.add_library('rt')
         elif sys.platform == 'win32':
             self.extensions[0].define_macros.append(('WIN32', 1))
-            self.extensions[0].extra_link_args.extend(['/NODEFAULTLIB:libcmt', '/LTCG'])
+            if self.compiler.compiler_type != 'mingw32':
+                self.extensions[0].extra_link_args.extend(['/NODEFAULTLIB:libcmt', '/LTCG'])
             self.compiler.add_library('advapi32')
             self.compiler.add_library('iphlpapi')
             self.compiler.add_library('psapi')


### PR DESCRIPTION
Minor fixes to enable building with MinGW-w64. The --use-system-libuv option is ignored and treated as true for MinGW builds.

Command for testing this branch

```
pip2 install git+https://github.com/equalsraf/pyuv@tb-mingw-w64
```

ref https://github.com/saghul/pyuv/issues/224#issuecomment-244449346
