### PR TITLE
Update documentation

### DIFF
--- a/docs/idle.rst
+++ b/docs/idle.rst
@@ -14,9 +14,18 @@
     :type loop: :py:class:`Loop`
     :param loop: loop object where this handle runs (accessible through :py:attr:`Idle.loop`).
 
-    ``Idle`` handles run when the event loop is *idle*, that is, there are no
-    other events pending to be run. It is usually used to defer operations to
-    be run at a later loop iteration.
+    ``Idle`` handles will run the given callback *once per loop iteration*, right
+    before the :py:class:`Prepare` handles.
+
+    .. note::
+        The notable difference with :py:class:`Prepare` handles is that
+        when there are active idle handles, the loop will perform a zero
+        timeout poll instead of blocking for I/O.
+
+    .. warning::
+        Despite the name, :py:class:`Idle` handles will get their callbacks
+        called on **every** loop iteration, not when the loop is actually
+        "idle".
 
 
     .. py:method:: start(callback)

--- a/docs/idle.rst
+++ b/docs/idle.rst
@@ -19,8 +19,8 @@
 
     .. note::
         The notable difference with :py:class:`Prepare` handles is that
-        when there are active idle handles, the loop will perform a zero
-        timeout poll instead of blocking for I/O.
+        when there are active :py:class:`Idle` handles, the loop will perform
+        a zero timeout poll instead of blocking for I/O.
 
     .. warning::
         Despite the name, :py:class:`Idle` handles will get their callbacks

--- a/docs/pipe.rst
+++ b/docs/pipe.rst
@@ -45,8 +45,8 @@
 
         Open the given file descriptor (or HANDLE in Windows) as a ``Pipe``.
 
-        ..note::
-            The file descriptor will be closed when the `UDP` handle is closed, so if it
+        .. note::
+            The file descriptor will be closed when the `Pipe` handle is closed, so if it
             was tasken from a Python socket object, it will be useless afterwards.
 
         .. note::

--- a/docs/tcp.rst
+++ b/docs/tcp.rst
@@ -77,7 +77,7 @@
 
         Open the given file descriptor (or SOCKET in Windows) as a ``TCP`` handle.
 
-        ..note::
+        .. note::
             The file descriptor will be closed when the `TCP` handle is closed, so if it
             was tasken from a Python socket object, it will be useless afterwards.
 

--- a/docs/udp.rst
+++ b/docs/udp.rst
@@ -42,7 +42,7 @@
 
         Open the given file descriptor (or SOCKET in Windows) as a ``UDP`` handle.
 
-        ..note::
+        .. note::
             The file descriptor will be closed when the `UDP` handle is closed, so if it
             was tasken from a Python socket object, it will be useless afterwards.
 


### PR DESCRIPTION
I spotted some directives that were not being applied, because they were missing a space after the two dots.

I ran `grep -R -E '(^|[^.])\.\.[^ /.]' docs` and it didn't hint at any other trouble with directives.

The paragraph on the `Pipe` might need some double checking though, as it refers to a socket object. (I assume it was copied from `UDP`.) That might need some changing, but it exceeds my expertise to guess, what would be correct to put here.