### PR TITLE
Fix building against python-3.10

### DIFF
--- a/src/handle.c
+++ b/src/handle.c
@@ -14,7 +14,11 @@ resurrect_object(PyObject *self)
     Py_ssize_t refcnt = Py_REFCNT(self);
     ASSERT(Py_REFCNT(self) != 0);
     _Py_NewReference(self);
+#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 10
+    Py_SET_REFCNT(self, refcnt);
+#else
     Py_REFCNT(self) = refcnt;
+#endif
     /* If Py_REF_DEBUG, _Py_NewReference bumped _Py_RefTotal, so
      * we need to undo that. */
 #ifdef _Py_DEC_REFTOTAL


### PR DESCRIPTION
Specifically this build error:

```
  In file included from src/pyuv.c:8:
  src/handle.c: In function ‘resurrect_object’:
  src/handle.c:17:21: error: lvalue required as left operand of assignment
     17 |     Py_REFCNT(self) = refcnt;
        |                     ^
```

Fixes https://github.com/saghul/pyuv/issues/271.

Co-authored-by: @polkovnikov