### PR TITLE
Fix building for Python3.11

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -39,7 +39,11 @@ pyuv_PyUnicode_EncodeFSDefault(PyObject *unicode)
         return PyUnicode_AsEncodedString(unicode, Py_FileSystemDefaultEncoding, "surrogateescape");
     else
 #endif
+    #if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 11
+        return PyUnicode_AsUTF8String(unicode);
+    #else
         return PyUnicode_EncodeUTF8(PyUnicode_AS_UNICODE(unicode), PyUnicode_GET_SIZE(unicode), "surrogateescape");
+    #endif
 }
 
 


### PR DESCRIPTION
Currently it is not possible to build pyuv for Python3.11 due to the following error:
```
ImportError: /python3.11/lib/python3.11/site-packages/pyuv/_cpyuv.cpython-311-x86_64-linux-gnu.so: undefined symbol: PyUnicode_EncodeUTF8
```
The error is cause since function `PyUnicode_EncodeUTF8` has been removed in Python3.11. 

This PR replaces `PyUnicode_EncodeUTF8` with the new function `PyUnicode_AsUTF8String`, for Python3.11.
